### PR TITLE
Expose the internal validate function.

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -26,7 +26,7 @@ var latest = Draft6
 
 func (draft *Draft) validateSchema(url, ptr string, v interface{}) error {
 	if meta := draft.meta; meta != nil {
-		if err := meta.validate(v); err != nil {
+		if err := meta.ValidateInterface(v); err != nil {
 			addContext(ptr, "", err)
 			finishSchemaContext(err, meta)
 			finishInstanceContext(err)


### PR DESCRIPTION
This permits users to pass in an interface, so that json decoding doesn't happen twice in case it has been decoded already.