### PR TITLE
int checks for whole numbers, avoiding json float64 concerns for large ints

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -173,8 +173,9 @@ func (s *Schema) validate(v interface{}) error {
 				matched = true
 				break
 			} else if t == "integer" && vType == "number" {
-				if _, ok := new(big.Int).SetString(fmt.Sprint(v), 10); ok {
-					matched = true
+				floatValue, err := strconv.ParseFloat(fmt.Sprint(v), 64)
+				if err == nil {
+					matched = floatValue == float64(int64(floatValue))
 					break
 				}
 			}

--- a/testdata/draft7/type.json
+++ b/testdata/draft7/type.json
@@ -42,6 +42,11 @@
                 "description": "null is not an integer",
                 "data": null,
                 "valid": false
+            },
+            {
+                "description": "a large integer is still an integer",
+                "data": 2147483647,
+                "valid": true
             }
         ]
     },


### PR DESCRIPTION
We're seeing an issue where mildly large integers are causing validation errors due to the way the golang json pkg unmarshals numbers.

Playground example here, using snippets of this library to reproduce the error:
https://play.golang.org/p/D-IKC0c8xD2 

Essentially the json unmarshaller will unmarshal large numbers into float64's, which ends up in a `fmt.Sprint(..)` value of `1.734598e+06` for `1734598`. `big.Int.SetString()` does not accept this value.

This change instead tests for whole numbers by comparing the original value and the new value after dropping the decimals.

**Note**: This change will fail, in that it wont generate a validation error, if the source JSON has a number like `1313.0`, as it's a whole number, but not an integer as specified.

Happy for this to be butchered, improved to work for both scenarios, just figured raising an issue with a potential fix attached was nicer than whinging with no suggestions. 