### PR TITLE
Allow hostname labels starting with digits

### DIFF
--- a/formats/formats.go
+++ b/formats/formats.go
@@ -97,7 +97,8 @@ func IsTime(s string) bool {
 }
 
 // IsHostname tells whether given string is a valid representation
-// for an Internet host name, as defined by RFC 1034, section 3.1.
+// for an Internet host name, as defined by RFC 1034 section 3.1 and
+// RFC 1123 section 2.1.
 //
 // See https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names, for details.
 func IsHostname(s string) bool {
@@ -114,8 +115,8 @@ func IsHostname(s string) bool {
 			return false
 		}
 
-		// labels could not start with a digit or with a hyphen
-		if first := s[0]; (first >= '0' && first <= '9') || (first == '-') {
+		// labels must not start with a hyphen
+		if first := s[0]; first == '-' {
 			return false
 		}
 

--- a/formats/formats.go
+++ b/formats/formats.go
@@ -116,6 +116,8 @@ func IsHostname(s string) bool {
 		}
 
 		// labels must not start with a hyphen
+		// RFC 1123 section 2.1: restriction on the first character
+		// is relaxed to allow either a letter or a digit
 		if first := s[0]; first == '-' {
 			return false
 		}


### PR DESCRIPTION
Long story short, we had code blow up today because valid customer email addresses were rejected because of numbers in the domain.

[RFC 1123](https://tools.ietf.org/html/rfc1123#page-13) modified [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.1) to allow hostname labels to begin with a digit. Although RFC 1123 has been around since 1989, it unfortunately appears that the JSON schema authors weren't aware of this, and only require that implementations be compliant with RFC 1034.

It's a bit of a snafu on the part of the JSON schema spec authors, really, since they require that the `email` format comply with [RFC 5322 section 3.4.1](https://tools.ietf.org/html/rfc5322#section-3.4.1), whose definition of a domain includes both RFC 1034 and RFC 1123, but they only require that the `hostname` format comply with RFC 1034.

Anyway, regardless of what the spec actually requires at a minimum, I recommend allowing hostname labels to begin with digits so that the `hostname` and `email` formats are actually useful in the real world.