### PR TITLE
feat: add MessageFmt method to error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -62,8 +62,13 @@ func (ve *ValidationError) add(causes ...error) error {
 	return ve
 }
 
+// MessageFmt returns the Message formatted, but does not include child Cause messages.
+func (ve *ValidationError) MessageFmt() string {
+	return fmt.Sprintf("I[%s] S[%s] %s", ve.InstancePtr, ve.SchemaPtr, ve.Message)
+}
+
 func (ve *ValidationError) Error() string {
-	msg := fmt.Sprintf("I[%s] S[%s] %s", ve.InstancePtr, ve.SchemaPtr, ve.Message)
+	msg := ve.MessageFmt()
 	for _, c := range ve.Causes {
 		for _, line := range strings.Split(c.Error(), "\n") {
 			msg += "\n  " + line


### PR DESCRIPTION
It would be nice to have access to the formatted message for each error in the error tree. Otherwise the only way to get each error formatted message separately is to duplicate the format string outside of this library.
