### PR TITLE
Use powerOf in extension test

### DIFF
--- a/extension_test.go
+++ b/extension_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ory/jsonschema/v3"
+ 	"github.com/santhosh-tekuri/jsonschema/v2"
 )
 
 func powerOfExt() jsonschema.Extension {

--- a/extension_test.go
+++ b/extension_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/santhosh-tekuri/jsonschema/v2"
+	"github.com/ory/jsonschema/v3"
 )
 
 func powerOfExt() jsonschema.Extension {
@@ -59,7 +59,7 @@ func TestPowerOfExt(t *testing.T) {
 	t.Run("invalidSchema", func(t *testing.T) {
 		c := jsonschema.NewCompiler()
 		c.Extensions["powerOf"] = powerOfExt()
-		if err := c.AddResource("test.json", strings.NewReader(`{"multipleOf": "hello"}`)); err != nil {
+		if err := c.AddResource("test.json", strings.NewReader(`{"powerOf": "hello"}`)); err != nil {
 			t.Fatal(err)
 		}
 		_, err := c.Compile("test.json")
@@ -71,7 +71,7 @@ func TestPowerOfExt(t *testing.T) {
 	t.Run("validSchema", func(t *testing.T) {
 		c := jsonschema.NewCompiler()
 		c.Extensions["powerOf"] = powerOfExt()
-		if err := c.AddResource("test.json", strings.NewReader(`{"multipleOf": 10}`)); err != nil {
+		if err := c.AddResource("test.json", strings.NewReader(`{"powerOf": 10}`)); err != nil {
 			t.Fatal(err)
 		}
 		sch, err := c.Compile("test.json")
@@ -87,6 +87,9 @@ func TestPowerOfExt(t *testing.T) {
 			if err := sch.Validate(strings.NewReader(`111`)); err == nil {
 				t.Fatal("validation must fail")
 			} else {
+				if !strings.Contains(err.Error(), "111 not powerOf 10") {
+					t.Fatal("validation error expected to contain powerOf message")
+				}
 				t.Log(err)
 			}
 		})


### PR DESCRIPTION
The test used multipleOf which did not actually use the powerOf extension which made the test non-sensical. A test case has been added to address possible regressions.