### PR TITLE
Add source pointer to schemas 

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -127,7 +127,7 @@ func (c *Compiler) compileRef(r *resource, base, ref string) (*Schema, error) {
 			if err := c.validateSchema(r, "", r.doc); err != nil {
 				return nil, err
 			}
-			s := &Schema{URL: r.url, Ptr: "#"}
+			s := &Schema{URL: r.url, Ptr: "#", Source: r.doc}
 			r.schemas["#"] = s
 			if _, err := c.compile(r, s, base, r.doc); err != nil {
 				return nil, err
@@ -145,7 +145,7 @@ func (c *Compiler) compileRef(r *resource, base, ref string) (*Schema, error) {
 			if err := c.validateSchema(r, strings.TrimPrefix(ref, "#/"), doc); err != nil {
 				return nil, err
 			}
-			r.schemas[ref] = &Schema{URL: base, Ptr: ref}
+			r.schemas[ref] = &Schema{URL: base, Ptr: ref, Source: doc}
 			if _, err := c.compile(r, r.schemas[ref], ptrBase, doc); err != nil {
 				return nil, err
 			}
@@ -170,7 +170,7 @@ func (c *Compiler) compileRef(r *resource, base, ref string) (*Schema, error) {
 			return nil, err
 		}
 		u, f := split(refURL)
-		s := &Schema{URL: u, Ptr: f}
+		s := &Schema{URL: u, Ptr: f, Source: v}
 		r.schemas[refURL] = s
 		if err := c.compileMap(r, s, refURL, v); err != nil {
 			return nil, err
@@ -190,6 +190,7 @@ func (c *Compiler) compile(r *resource, s *Schema, base string, m interface{}) (
 		s = new(Schema)
 		s.URL, _ = split(base)
 	}
+	s.Source = m
 	switch m := m.(type) {
 	case bool:
 		s.Always = &m

--- a/schema.go
+++ b/schema.go
@@ -18,8 +18,9 @@ import (
 
 // A Schema represents compiled version of json-schema.
 type Schema struct {
-	URL string // absolute url of the resource.
-	Ptr string // json-pointer to schema. always starts with `#`.
+	URL    string      // absolute url of the resource.
+	Ptr    string      // json-pointer to schema. always starts with `#`.
+	Source interface{} // The source document of this schema
 
 	// type agnostic validations
 	format    func(interface{}) bool


### PR DESCRIPTION
This change adds a Source pointer to the schema struct. After schema compilation, this Source can be used to refer to the schema source and collect additional information (such as description, extensions, etc.). 

I am using this in a project that compiles JSON schemas and extracts information from them. 

