### PR TITLE
Allow cmd/jv to validate yaml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vscode
 .idea
 *.swp
-jv
+/jv
+/cmd/jv/jv
+*.exe

--- a/cmd/jv/go.mod
+++ b/cmd/jv/go.mod
@@ -1,0 +1,8 @@
+module github.com/santhosh-tekuri/jsonschema/cmd/jv
+
+go 1.15
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/cmd/jv/go.sum
+++ b/cmd/jv/go.sum
@@ -1,0 +1,6 @@
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 h1:TToq11gyfNlrMFZiYujSekIsPd9AmsA2Bj/iv+s4JHE=
+github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
If a file provided to cmd/jv ends in .yaml or .yml, instead of unmarshalling as a JSON file it's instead unmarshalled as YAML and validated as per the instructions in the README file.

A few other cleanups of cmd/jv were done at the same time:
Move validation to a separate func so defer file.Close() calls Close sooner (current behaviour holds the file handles open for every file being validated due to defer being called within a for loop)
Create a separate go.mod file for cmd/jv so the newly added yaml dependency doesn't pollute the main library
Fix .gitignore file to not ignore the entire cmd/jv folder
Make error output include the filename