### PR TITLE
Support ECMA 262 regular expressions

### DIFF
--- a/format.go
+++ b/format.go
@@ -5,10 +5,11 @@ import (
 	"net"
 	"net/mail"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/dlclark/regexp2"
 )
 
 // Formats is a registry of functions, which know how to validate
@@ -465,13 +466,13 @@ func isURITemplate(v interface{}) bool {
 // isRegex tells whether given string is a valid regular expression,
 // according to the ECMA 262 regular expression dialect.
 //
-// The implementation uses go-lang regexp package.
+// The implementation uses the github.com/dlclark/regexp2 package.
 func isRegex(v interface{}) bool {
 	s, ok := v.(string)
 	if !ok {
 		return true
 	}
-	_, err := regexp.Compile(s)
+	_, err := regexp2.Compile(s, regexp2.ECMAScript)
 	return err == nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/santhosh-tekuri/jsonschema/v5
 
 go 1.15
+
+require github.com/dlclark/regexp2 v1.8.0


### PR DESCRIPTION
Although `regexp` from the Go standard library doesn't support lookaheads, they are described in ECMA 262, and JSON Schema [appears to follow](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions) that.  Since clients validating documents with JSON schema cannot always control the input, it is not always possible to avoid consuming regular expressions with lookaheads.  So ideally, the validator could work with them.

The regular expression engine from https://github.com/dlclark/regexp2 supports an ECMAScript option.  It doesn't provide the same performance guarantees as the standard library, but can be configured with a match timeout.

Would there be support for switching regular expression implementations?  If committing to this alt package doesn't feel right, I could put together a change that adds an interface that could be supported by either the standard lib regular expressions or something like https://github.com/dlclark/regexp2.  Then a new function could be exported to switch out the default (`regexp`) implementation.

Fixes #31.