### PR TITLE
Allow regular expression provider to be changed

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -392,9 +391,11 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 
 	if patternProps, ok := m["patternProperties"]; ok {
 		patternProps := patternProps.(map[string]interface{})
-		s.PatternProperties = make(map[*regexp.Regexp]*Schema, len(patternProps))
+		s.PatternProperties = make(map[Regexp]*Schema, len(patternProps))
 		for pattern := range patternProps {
-			s.PatternProperties[regexp.MustCompile(pattern)], err = compile(nil, "patternProperties/"+escape(pattern))
+			re := newRegexp()
+			re.MustCompile(pattern)
+			s.PatternProperties[re], err = compile(nil, "patternProperties/"+escape(pattern))
 			if err != nil {
 				return err
 			}
@@ -499,7 +500,9 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 	s.MinLength, s.MaxLength = loadInt("minLength"), loadInt("maxLength")
 
 	if pattern, ok := m["pattern"]; ok {
-		s.Pattern = regexp.MustCompile(pattern.(string))
+		re := newRegexp()
+		re.MustCompile(pattern.(string))
+		s.Pattern = re
 	}
 
 	if format, ok := m["format"]; ok {

--- a/format.go
+++ b/format.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/mail"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -435,13 +434,14 @@ func isURITemplate(v interface{}) bool {
 // isRegex tells whether given string is a valid regular expression,
 // according to the ECMA 262 regular expression dialect.
 //
-// The implementation uses go-lang regexp package.
+// The default implementation uses go-lang regexp package.
 func isRegex(v interface{}) bool {
 	s, ok := v.(string)
 	if !ok {
 		return true
 	}
-	_, err := regexp.Compile(s)
+	re := newRegexp()
+	err := re.Compile(s)
 	return err == nil
 }
 

--- a/regexp.go
+++ b/regexp.go
@@ -1,0 +1,49 @@
+package jsonschema
+
+import "regexp"
+
+// Regexp is an interface for working with regular expressions.
+type Regexp interface {
+	MustCompile(expr string)
+	Compile(expr string) error
+	MatchString(s string) bool
+	String() string
+}
+
+// RegexpProvider greates a new unitialized regular expression.
+type RegexpProvider func() Regexp
+
+var newRegexp RegexpProvider = func() Regexp {
+	return &defaultRegexp{}
+}
+
+// SetRegexpProvider can be called to change the default regular expression provider.
+//
+// By default, the standard library regexp package is used.
+func SetRegexpProvider(f RegexpProvider) {
+	newRegexp = f
+}
+
+type defaultRegexp struct {
+	re *regexp.Regexp
+}
+
+var _ Regexp = (*defaultRegexp)(nil)
+
+func (r *defaultRegexp) MustCompile(expr string) {
+	r.re = regexp.MustCompile(expr)
+}
+
+func (r *defaultRegexp) Compile(expr string) error {
+	re, err := regexp.Compile(expr)
+	r.re = re
+	return err
+}
+
+func (r *defaultRegexp) MatchString(s string) bool {
+	return r.re.MatchString(s)
+}
+
+func (r *defaultRegexp) String() string {
+	return r.re.String()
+}

--- a/schema.go
+++ b/schema.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -45,7 +44,7 @@ type Schema struct {
 	Properties            map[string]*Schema
 	PropertyNames         *Schema
 	RegexProperties       bool // property names must be valid regex. used only in draft4 as workaround in metaschema.
-	PatternProperties     map[*regexp.Regexp]*Schema
+	PatternProperties     map[Regexp]*Schema
 	AdditionalProperties  interface{}            // nil or bool or *Schema.
 	Dependencies          map[string]interface{} // map value is *Schema or []string.
 	DependentRequired     map[string][]string
@@ -69,7 +68,7 @@ type Schema struct {
 	// string validations
 	MinLength        int // -1 if not specified.
 	MaxLength        int // -1 if not specified.
-	Pattern          *regexp.Regexp
+	Pattern          Regexp
 	ContentEncoding  string
 	decoder          func(string) ([]byte, error)
 	ContentMediaType string


### PR DESCRIPTION
Since regular expressions used [in JSON schema](http://json-schema.org/understanding-json-schema/reference/regular_expressions.html) docs aren't restricted to the [RE2 syntax](https://github.com/google/re2/wiki/Syntax), it would be ideal if the validator could be configured to use something other than the [`regexp` package](https://pkg.go.dev/regexp).

This pull request suggests making it possible to configure the regular expression provider used by the validator.  New exported names:
 * `jsonschema.Regexp` - an interface for working with regular expressions
 * `jsonschema.RegexpProvider` - a function type for supplying a regular expression
 * `jsonschema.SetRegexpProvider` - sets the default regular expression provider

With these changes, here is an example of how you could use the `github.com/dlclark/regexp2` package to parse ECMAScript-flavor regex (the flavor used in JSON Schema):
```go
package main

import (
	"encoding/json"
	"log"
	"time"

	"github.com/dlclark/regexp2"
	"github.com/santhosh-tekuri/jsonschema/v5"
)

func init() {
	// configure the default regexp provider
	jsonschema.SetRegexpProvider(func() jsonschema.Regexp {
		return &ecmaRegexp{}
	})
}

type ecmaRegexp struct {
	re *regexp2.Regexp
}

// ecmaRegexp implements the jsonschema.Regexp interface
var _ jsonschema.Regexp = (*ecmaRegexp)(nil)

func (r *ecmaRegexp) Compile(expr string) error {
	re, err := regexp2.Compile(expr, regexp2.ECMAScript)
	if err != nil {
		return err
	}
	re.MatchTimeout = time.Second
	r.re = re
	return nil
}

func (r *ecmaRegexp) MustCompile(expr string) {
	re := regexp2.MustCompile(expr, regexp2.ECMAScript)
	re.MatchTimeout = time.Second
	r.re = re
}

func (r *ecmaRegexp) MatchString(s string) bool {
	match, _ := r.re.MatchString(s)
	return match
}

func (r *ecmaRegexp) String() string {
	return r.re.String()
}

func main() {
	// schema with a negative lookahead
	// allowed in JSON schema but not the golang regexp package
	schema, err := jsonschema.CompileString("schema.json", `
		{
			"type": "string",
			"pattern": "^(?!foo)" 
		}
	`)
	if err != nil {
		log.Fatal(err)
	}

	var v interface{}
	if err := json.Unmarshal([]byte(`"bar"`), &v); err != nil {
		log.Fatal(err)
	}

	if err = schema.Validate(v); err != nil {
		log.Fatalf("%#v\n", err)
	}
}
```

Alternatively, the `github.com/dlclark/regexp2` package could be used by default (see #60).

Fixes #31.