### PR TITLE
Add commments to extension example.

### DIFF
--- a/example_extension_test.go
+++ b/example_extension_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
+// Define a schema for the new keyword itself. This schema will be used to
+// validate appearance of the keyword in a schema before passing it to the
+// compiler. This example defines the `powerOf` property of a JSON object in a
+// schema as an integer greater than 0. This value will be used to ensure that
+// numbers the schema applies to are powers of the value.
 var powerOfMeta = jsonschema.MustCompileString("powerOf.json", `{
 	"properties" : {
 		"powerOf": {
@@ -19,8 +24,20 @@ var powerOfMeta = jsonschema.MustCompileString("powerOf.json", `{
 	}
 }`)
 
+// Define an objext to use for compiling. All the interesting logic lives in the
+// Compile method.
 type powerOfCompiler struct{}
 
+// Compile is called after the metaschema has been applied to the appearance of
+// the keyword, so we know the value is an integer greater than 0. It reads the
+// value of the powerOf property from m, which is part of the schema definion.
+// It then ensures that the schema has a valid value for the keyword. In our
+// example, we need to ensure that the schema value is an int64, so we convert
+// from a JSON number and return an error if it's not a valid value. If it is
+// valid, return an ExtSchema value, here defined by powerOfSchema. This is the
+// compiled representation of the keyword value from the schema, to be used for
+// validation of documents. If the powerOf property does not appear in m, there
+// is nothing to compile.
 func (powerOfCompiler) Compile(ctx jsonschema.CompilerContext, m map[string]interface{}) (jsonschema.ExtSchema, error) {
 	if pow, ok := m["powerOf"]; ok {
 		n, err := pow.(json.Number).Int64()
@@ -31,8 +48,16 @@ func (powerOfCompiler) Compile(ctx jsonschema.CompilerContext, m map[string]inte
 	return nil, nil
 }
 
+// Define a type to represent the compiled form of the keyword parsed from a
+// schema. In our case the value is just an int64 value, but more complicated
+// keywords might require a more complex type like a struct.
 type powerOfSchema int64
 
+// Validate examines the value v to ensure that it is valid according to the
+// schema s. In our case, we need to validate that the value from the document
+// is a power of the powerOf value specified in the schema. So we convert the
+// value to an int64 and return an error if it is not evenly divisible by the
+// schema's powerOf value.
 func (s powerOfSchema) Validate(ctx jsonschema.ValidationContext, v interface{}) error {
 	switch v.(type) {
 	case json.Number, float64, int, int32, int64:
@@ -51,12 +76,17 @@ func (s powerOfSchema) Validate(ctx jsonschema.ValidationContext, v interface{})
 }
 
 func Example_extension() {
+	// Create the compiler and register the powerOf Keyword. Use powerOfMeta to
+	// validate its appearance in a schema.
 	c := jsonschema.NewCompiler()
 	c.RegisterExtension("powerOf", powerOfMeta, powerOfCompiler{})
 
+	// Define a schema with the keyword and a JSON value to validate with that
+	// schema.
 	schema := `{"powerOf": 10}`
 	instance := `100`
 
+	// Compile the schema.
 	if err := c.AddResource("schema.json", strings.NewReader(schema)); err != nil {
 		log.Fatal(err)
 	}
@@ -65,11 +95,16 @@ func Example_extension() {
 		log.Fatalf("%#v", err)
 	}
 
+	// Convert the instance JSON value. We use an interface{} to ensure that
+	// valid JSON parses cleanly even if the value is not a number. Feel free
+	// to use a more defined type if it suits your needs.
 	var v interface{}
 	if err := json.Unmarshal([]byte(instance), &v); err != nil {
 		log.Fatal(err)
 	}
 
+	// Validate the JSON value against the schema! Since the schema defines a
+	// powerOf 10 and the value is 100, it is valid and this method returns nil.
 	if err = sch.Validate(v); err != nil {
 		log.Fatalf("%#v", err)
 	}

--- a/extension.go
+++ b/extension.go
@@ -11,7 +11,7 @@ type ExtCompiler interface {
 // ExtSchema is schema representation of custom keyword(s)
 type ExtSchema interface {
 	// Validate validates the json value v with this ExtSchema.
-	// Returned error must be *ValidationError.
+	// Returned error must be *ValidationError or nil.
 	Validate(ctx ValidationContext, v interface{}) error
 }
 
@@ -83,7 +83,7 @@ func (ctx ValidationContext) EvaluatedProp(prop string) {
 	delete(ctx.result.unevalProps, prop)
 }
 
-// EvaluatedItem marks given index of array as evaluated.
+// EvaluatedItem marks given index of an array as evaluated.
 func (ctx ValidationContext) EvaluatedItem(index int) {
 	delete(ctx.result.unevalItems, index)
 }


### PR DESCRIPTION
The goal is to make it clearer what bits do what and how it all goes together, so a user can more quickly get started with custom keywords.