### PR TITLE
[format/period] add support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Package jsonschema provides json-schema compilation and validation.
  - compiled schema can be introspected. easier to develop tools like generating go structs given schema
  - supports user-defined keywords via [extensions](https://pkg.go.dev/github.com/santhosh-tekuri/jsonschema/v5/#example-package-Extension)
  - implements following formats (supports [user-defined](https://pkg.go.dev/github.com/santhosh-tekuri/jsonschema/v5/#example-package-UserDefinedFormat))
-   - date-time, date, time, duration (supports leap-second)
+   - date-time, date, time, duration, period (supports leap-second)
    - uuid, hostname, email
    - ip-address, ipv4, ipv6
    - uri, uriref, uri-template(limited validation)

--- a/format.go
+++ b/format.go
@@ -21,6 +21,7 @@ var Formats = map[string]func(interface{}) bool{
 	"date":                  isDate,
 	"time":                  isTime,
 	"duration":              isDuration,
+	"period":                isPeriod,
 	"hostname":              isHostname,
 	"email":                 isEmail,
 	"ip-address":            isIPV4,
@@ -232,6 +233,26 @@ func isDuration(v interface{}) bool {
 	s = s[1:]
 	units, ok = parseUnits()
 	return ok && len(s) == 0 && len(units) > 0 && strings.Index("HMS", units) != -1
+}
+
+// isPeriod tells whether given string is a valid period format
+// from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
+//
+// see https://datatracker.ietf.org/doc/html/rfc3339#appendix-A, for details
+func isPeriod(v interface{}) bool {
+	s, ok := v.(string)
+	if !ok {
+		return true
+	}
+	slash := strings.IndexByte(s, '/')
+	if slash == -1 {
+		return false
+	}
+	start, end := s[:slash], s[slash+1:]
+	if isDateTime(start) {
+		return isDateTime(end) || isDuration(end)
+	}
+	return isDuration(start) && isDateTime(end)
 }
 
 // isHostname tells whether given string is a valid representation

--- a/format_test.go
+++ b/format_test.go
@@ -134,6 +134,30 @@ func TestIsDuration(t *testing.T) {
 	}
 }
 
+func TestIsPeriod(t *testing.T) {
+	dt := "1963-06-19T08:30:06Z"
+	dur := "P4DT12H30M5S"
+	tests := []test{
+		{dt + "/" + dt, true},  // period-explicit
+		{dt + "/" + dur, true}, // period-start
+		{dur + "/" + dt, true}, // period-end
+		{dur + "/" + dur, false},
+		{dt, false},
+		{dur, false},
+		{dt + "/" + dt + "/" + dt, false},
+		{dt + " " + dt, false},
+		{dt + "-" + dt, false},
+		{"foo/bar", false},
+		{"", false},
+		{"/", false},
+	}
+	for i, test := range tests {
+		if test.valid != isPeriod(test.str) {
+			t.Errorf("#%d: %q, valid %t, got valid %t", i, test.str, test.valid, !test.valid)
+		}
+	}
+}
+
 func TestIsHostname(t *testing.T) {
 	tests := []test{
 		{"www.example.com", true},


### PR DESCRIPTION
Not a separately mentioned SHOULD in [draft-bhutton-json-schema-validation-01](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01#section-7.3.1), but falls under the "MAY support additional attributes using the other format names defined anywhere in that [RFC [3339]](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A)".