### PR TITLE
Adds status check to prevent panics when dealing with malformed numbers

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -240,7 +240,7 @@ func (s *Schema) validate(scope []schemaRef, vscope int, spath string, v interfa
 			} else if t == "integer" && vType == "number" {
 				num, ok := new(big.Rat).SetString(fmt.Sprint(v))
 				if !ok {
-					return result, validationError("", "malformed number: %s", fmt.Sprint(v))
+					return result, validationError("type", "malformed number: %s", fmt.Sprint(v))
 				}
 				if num.IsInt() {
 					matched = true
@@ -527,7 +527,7 @@ func (s *Schema) validate(scope []schemaRef, vscope int, spath string, v interfa
 				var ok bool
 				numVal, ok = new(big.Rat).SetString(fmt.Sprint(v))
 				if !ok {
-					return nil, validationError("", "malformed number: %v", fmt.Sprintf("%v", v))
+					return nil, validationError("type", "malformed number: %v", fmt.Sprintf("%v", v))
 				}
 			}
 			return numVal, nil

--- a/schema_test.go
+++ b/schema_test.go
@@ -675,6 +675,24 @@ func TestFilePathSpaces(t *testing.T) {
 	}
 }
 
+func TestIssue77(t *testing.T) {
+	schema := `{"type": "integer"}`
+	instance := json.Number("abc")
+
+	sch, err := jsonschema.CompileString("schema.json", schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = sch.Validate(instance); err == nil {
+		t.Fatal("error expected")
+	} else {
+		var verr *jsonschema.ValidationError
+		if !errors.As(err, &verr) {
+			t.Fail()
+		}
+	}
+}
+
 func runHTTPServers() (httpURL, httpsURL string, cleanup func()) {
 	tr := http.DefaultTransport.(*http.Transport)
 	if tr.TLSClientConfig == nil {


### PR DESCRIPTION
Closes #77.

Adds checks for the status of `big.Rat`'s `SetString` method when dealing with numbers.

I was uncertain of what `keywordPath` should be for the `ValidationError` but I've updated it to use  `"type"` for now. Please let me know if I should change that or the error message.