### PR TITLE
Resolves panics over malformed numbers & removes calls to panic entirely

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -258,7 +258,7 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 	}
 	stack = append(stack, sref)
 
-	var s = res.schema
+	s := res.schema
 	var err error
 
 	if ref, ok := m["$ref"]; ok {
@@ -301,11 +301,16 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 	if e, ok := m["enum"]; ok {
 		s.Enum = e.([]interface{})
 		allPrimitives := true
+		var err error
+		var typ string
 		for _, item := range s.Enum {
-			switch jsonType(item) {
+			typ, err = jsonType(item)
+			if err != nil {
+				return err
+			}
+			switch typ {
 			case "object", "array":
 				allPrimitives = false
-				break
 			}
 		}
 		s.enumError = "enum failed"

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,72 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestInvalidJSONTypeErrorIs(t *testing.T) {
+	data := json.RawMessage(`{"type": invalid}`)
+	err := invalidJSONTypeError(data)
+	if !errors.Is(err, ErrInvalidJSON) {
+		t.Errorf("%T did not register as ErrInvalidJSON", err)
+	}
+
+	err2 := invalidJSONTypeError(data)
+
+	if !errors.Is(err, err2) {
+		t.Errorf("%v should report true for %v", err, err2)
+	}
+
+	var ierr *InvalidJSONTypeError
+	if !errors.As(err, &ierr) {
+		t.Errorf("%v should be able to use errors.As for %T", err, ierr)
+	}
+}
+
+func TestIsValidationError(t *testing.T) {
+	var ve error = &ValidationError{}
+
+	if !IsValidationError(ve) {
+		t.Errorf("%v should be a validation error", ve)
+	}
+}
+
+func TestInvalidJSONTypeAs(t *testing.T) {
+	var err error = invalidJSONTypeError("error_value")
+
+	var ptrerr *InvalidJSONTypeError
+
+	if !errors.As(err, &ptrerr) {
+		t.Errorf("%v should be able to use errors.As for %T", err, ptrerr)
+	} else if string(*ptrerr) != "string" {
+		t.Errorf("expected \"string\", got %s", string(*ptrerr))
+	}
+
+	var regerr InvalidJSONTypeError
+	if !errors.As(err, &regerr) {
+		t.Errorf("%v should be able to use errors.As for %T", err, err)
+	} else if string(regerr) != "string" {
+		t.Errorf("expected \"string\", got %s", string(regerr))
+	}
+}
+
+func TestInfiniteLoopErrorAs(t *testing.T) {
+	var err error = InfiniteLoopError("infinite_loop")
+
+	var ptrerr *InfiniteLoopError
+
+	if !errors.As(err, &ptrerr) {
+		t.Errorf("%v should be able to use errors.As for %T", err, ptrerr)
+	} else if string(*ptrerr) != "infinite_loop" {
+		t.Errorf("expected \"infinite_loop\", got %s", string(*ptrerr))
+	}
+
+	var regerr InfiniteLoopError
+	if !errors.As(err, &regerr) {
+		t.Errorf("%v should be able to use errors.As for %T", err, err)
+	} else if string(regerr) != "infinite_loop" {
+		t.Errorf("expected \"infinite_loop\", got %s", string(regerr))
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -250,7 +250,7 @@ func testFolder(t *testing.T, folder string, draft *jsonschema.Draft) {
 					}
 					c := jsonschema.NewCompiler()
 					c.Draft = draft
-					if strings.Index(folder, "optional") != -1 {
+					if strings.Contains(folder, "optional") {
 						c.AssertFormat = true
 					}
 					if err := c.AddResource("schema.json", bytes.NewReader(group.Schema)); err != nil {
@@ -672,6 +672,23 @@ func TestCompiler_LoadURL(t *testing.T) {
 func TestFilePathSpaces(t *testing.T) {
 	if _, err := jsonschema.Compile("testdata/person schema.json"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestIssue77(t *testing.T) {
+	schema := `{"type": "integer"}`
+	instance := json.Number("abc")
+
+	sch, err := jsonschema.CompileString("schema.json", schema)
+	if err != nil {
+		t.Error(err)
+	}
+	if err = sch.Validate(instance); err == nil {
+		t.Error("error expected")
+	} else {
+		if !errors.Is(err, jsonschema.ErrInvalidJSON) {
+			t.Fail()
+		}
 	}
 }
 


### PR DESCRIPTION
A few things this pull request does:
- Closes #77
- Removes calls to panic entirely
- Removes recovery as the code no longer panics
- Adds `IsValidationError` and `AsValidationError` (utilizing go 1.13 errors)
- Adds `As` methods to `InfiniteLoopError` and `InvalidJSONTypeError` so that `errors.As` can be performed on either a pointer or non-pointer value
- Removes a few unnecessary allocations wrt to `if err :=` calls

This is an alternative to #78 which has since been closed in favor of this. 

This pull request has required a somewhat substantial refactor but makes the package more idiomatic, performant (by removing panics and recovery as well as reducing some allocations), and addresses a bug causing unrecovered panics. 