### PR TITLE
Add instructions for installing jv CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Prints:
 
 ## CLI
 
+to install `go install github.com/santhosh-tekuri/jsonschema/v5/cmd/jv@latest`
+
 ```bash
 jv [-draft INT] [-output FORMAT] [-assertformat] <json-schema> [<json-doc>]...
   -assertformat


### PR DESCRIPTION
This MR adds instructions for installing the CLI since it wasn't obvious until I read [this issue](https://github.com/santhosh-tekuri/jsonschema/issues/42).