### PR TITLE
Store Id field

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -683,19 +683,8 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 		}
 	}
 
-	if r.draft.version == 4 {
-		if c.ExtractAnnotations {
-			if id, ok := m["id"]; ok {
-				s.Id = id.(string)
-			}
-		}
-	}
-	if r.draft.version > 4 {
-		if c.ExtractAnnotations {
-			if id, ok := m["$id"]; ok {
-				s.Id = id.(string)
-			}
-		}
+	if c.ExtractAnnotations {
+		s.Id = r.draft.getID(m)
 	}
 
 	if r.draft.version >= 2019 {

--- a/compiler.go
+++ b/compiler.go
@@ -683,6 +683,21 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 		}
 	}
 
+	if r.draft.version == 4 {
+		if c.ExtractAnnotations {
+			if id, ok := m["id"]; ok {
+				s.Id = id.(string)
+			}
+		}
+	}
+	if r.draft.version > 4 {
+		if c.ExtractAnnotations {
+			if id, ok := m["$id"]; ok {
+				s.Id = id.(string)
+			}
+		}
+	}
+
 	if r.draft.version >= 2019 {
 		if !c.AssertContent {
 			s.decoder = nil

--- a/schema.go
+++ b/schema.go
@@ -87,6 +87,7 @@ type Schema struct {
 	MultipleOf       *big.Rat
 
 	// annotations. captured only when Compiler.ExtractAnnotations is true.
+	Id          string
 	Title       string
 	Description string
 	Default     interface{}


### PR DESCRIPTION
Make the `id` field from schema doc visible to user. This PD adds the `Id` field  to `schema` struct and populates it using `draft.getID` method. Otherwise, the contents of the `id` field is not visible.