### PR TITLE
feat: support truncated output and validation error should write in buffer

### DIFF
--- a/output.go
+++ b/output.go
@@ -75,3 +75,38 @@ func (ve *ValidationError) DetailedOutput() Detailed {
 		Errors:                  errors,
 	}
 }
+
+// Truncated return output in format
+type Truncated struct {
+	Valid                   bool         `json:"valid"`
+	KeywordLocation         string       `json:"keywordLocation"`
+	AbsoluteKeywordLocation string       `json:"absoluteKeywordLocation"`
+	InstanceLocation        string       `json:"instanceLocation"`
+	Error                   string       `json:"error,omitempty"`
+	Errors                  []BasicError `json:"errors,omitempty"`
+}
+
+func (ve *ValidationError) TruncatedOutput() Truncated {
+	var errors []BasicError
+	var flatten func(*ValidationError)
+	flatten = func(ve *ValidationError) {
+		errors = append(errors, BasicError{
+			KeywordLocation:         ve.KeywordLocation,
+			AbsoluteKeywordLocation: ve.AbsoluteKeywordLocation,
+			InstanceLocation:        ve.InstanceLocation,
+			Error:                   ve.Message,
+		})
+		for _, cause := range ve.Causes {
+			flatten(cause)
+			break
+		}
+	}
+	flatten(ve)
+	return Truncated{
+		KeywordLocation:         ve.KeywordLocation,
+		AbsoluteKeywordLocation: ve.AbsoluteKeywordLocation,
+		InstanceLocation:        ve.InstanceLocation,
+		Error:                   ve.Message,
+		Errors:                  errors,
+	}
+}


### PR DESCRIPTION
for large file validation will cause mess error and output will be huge:
1. support tuncated output should first level validation error
2. validationError GoString concat using byte Buffer for better performance