### PR TITLE
fix: escape % in enum validationError message

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -297,7 +297,7 @@ func (s *Schema) validate(scope []schemaRef, vscope int, spath string, v interfa
 			}
 		}
 		if !matched {
-			errors = append(errors, validationError("enum", s.enumError))
+			errors = append(errors, validationError("enum", strings.ReplaceAll(s.enumError, "%", "%%")))
 		}
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -440,7 +440,7 @@ func TestInvalidJsonTypeError(t *testing.T) {
 	}
 }
 
-func TestInvalidEnumError(t *testing.T) {
+func TestPercentInEnumError(t *testing.T) {
 	compiler := jsonschema.NewCompiler()
 	err := compiler.AddResource("test.json", strings.NewReader(`{"type": "string", "enum": ["%"]}`))
 	if err != nil {
@@ -451,8 +451,8 @@ func TestInvalidEnumError(t *testing.T) {
 		t.Fatalf("schema compilation failed. reason: %v\n", err)
 	}
 	err = schema.Validate("hello world")
-	if strings.Contains(err.Error(), `%!"(MISSING)`) {
-		t.Fatalf("got %v. want error with %% char", err)
+	if strings.Contains(err.Error(), `"%!"(MISSING)`) {
+		t.Fatalf(`error contains "%%!"(MISSING)`)
 	}
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -440,6 +440,22 @@ func TestInvalidJsonTypeError(t *testing.T) {
 	}
 }
 
+func TestInvalidEnumError(t *testing.T) {
+	compiler := jsonschema.NewCompiler()
+	err := compiler.AddResource("test.json", strings.NewReader(`{"type": "string", "enum": ["%"]}`))
+	if err != nil {
+		t.Fatalf("addResource failed. reason: %v\n", err)
+	}
+	schema, err := compiler.Compile("test.json")
+	if err != nil {
+		t.Fatalf("schema compilation failed. reason: %v\n", err)
+	}
+	err = schema.Validate("hello world")
+	if strings.Contains(err.Error(), `%!"(MISSING)`) {
+		t.Fatalf("got %v. want error with %% char", err)
+	}
+}
+
 func TestInfiniteLoopError(t *testing.T) {
 	t.Run("compile", func(t *testing.T) {
 		compiler := jsonschema.NewCompiler()


### PR DESCRIPTION
Due to the way that the `validationError` constructs its Message (https://github.com/santhosh-tekuri/jsonschema/blob/master/schema.go#L199), the `s.enumError` message is treated as a formatted string. This means that for a schema using an `enum`, if one of the enum values has a `%` (percent) character in it and validation fails, then this section of the error message gets interpreted as a formatting verb (e.g. `%"`) which then ends up becoming an inline format error.

Example `s.enumError`:

    jsonschema: '' does not validate with test.json#/enum: value must be "%"

Resulting `validationError.Message`:

    jsonschema: '' does not validate with test.json#/enum: value must be "%!"(MISSING)

The error would vary depending where the `%` is in the enum value - for example, an enum such as `"%davidjb"` would yield `"%!d(MISSING)avidjb"`, since the `%d` gets considered the verb.

This PR escapes any `%` characters with `%%` during creation of the `validationError` so as to avoid the issue. 
