### PR TITLE
fix: sort additionalProperties for consistency

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -783,6 +783,10 @@ func (vr validationResult) unevalPnames() string {
 	for pname := range vr.unevalProps {
 		pnames = append(pnames, quote(pname))
 	}
+
+	// Ensure deterministic order
+	sort.Strings(pnames)
+
 	return strings.Join(pnames, ", ")
 }
 


### PR DESCRIPTION
We're seeing local unit tests fail due to the order of `additionalProperties` in error messages changing from one run to the next.  Sorting these ensures the order is deterministic (and, thus, test behavior is as well.)

All tests pass.

(Note: It might be helpful to add a "Contributing" section to the README that explains users will need to run `git submodule update --init --recursive` to install the `testdata` directories in order for tests to pass.)