### PR TITLE
fix: initialise subresources to avoid nil pointers

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -40,7 +40,6 @@ func newResource(url string, r io.Reader) (*resource, error) {
 		url:  url,
 		floc: "#",
 		doc:  doc,
-		subresources: make(map[string]*resource),
 	}, nil
 }
 
@@ -48,6 +47,10 @@ func newResource(url string, r io.Reader) (*resource, error) {
 func (r *resource) fillSubschemas(c *Compiler, res *resource) error {
 	if err := c.validateSchema(r, res.doc, res.floc[1:]); err != nil {
 		return err
+	}
+
+	if r.subresources == nil {
+		r.subresources = make(map[string]*resource)
 	}
 
 	if err := r.draft.listSubschemas(res, r.baseURL(res.floc), r.subresources); err != nil {

--- a/schema_test.go
+++ b/schema_test.go
@@ -666,6 +666,48 @@ func TestFilePathSpaces(t *testing.T) {
 	}
 }
 
+func TestCompiler_ReusedDefinition(t *testing.T) {
+	c := jsonschema.NewCompiler()
+	c.Draft = jsonschema.Draft2019
+
+	def := `
+	{
+		"type": "object",
+		"required": [
+			"departure",
+			"departure"
+		],
+		"properties": {
+			"foo": {
+			"type": "string"
+			}
+		}
+	}`
+	schema := `
+	{
+		"type": "object",
+		"properties": {
+			"example-def": {
+				"$ref": "example-definition.json"
+			}
+		}
+	}`
+
+	if err := c.AddResource("response-post-example.json", strings.NewReader(schema)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddResource("request-post-example.json", strings.NewReader(schema)); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddResource("example-definition.json", strings.NewReader(def)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = c.Compile("response-post-example.json")
+	_, _ = c.Compile("request-post-example.json")
+
+}
+
 func TestSchemaDraftFeild(t *testing.T) {
 	var schemas = map[string]string{
 		"main.json": `{"$schema": "https://json-schema.org/draft/2020-12/schema", "$ref":"obj.json"}`,


### PR DESCRIPTION
In some rare cases, `subresources` field in the `resource` struct is not initialised, which leads to nil pointer errors. `fillSubschemas` does a nil check and creates a map if necessary, but considering `subresources` is used elsewhere without a nil check, I figured it'd be best to create it during the initialisation of the `resource` struct.

As an example:
openapi.json references `request-post-example.json`
`request-post-example.json`:
```
{
  "type": "object",
  "properties": {
    "journeys": {
      "type": "array",
      "minItems": 1,
      "items": {
        "$ref": "example-definition.json"
      }
    }
  }
}
``` 
`example-definition.json`:
```
{
  "type": "object",
  "required": [
    "ref_id",
    "departure",
    "departure",
    "arrival"
  ],
  "description": "This is an example",
  "properties": {
    "ref_id": {
      "type": "string"
    },
    "departure": {
      "type": "string"
    },
    "arrival": {
      "type": "string"
    }
  }
}
```
This specific case creates a nil pointer.