### PR TITLE
feature: allow resources to be added from a map directly. 

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -118,6 +118,16 @@ func (c *Compiler) AddResource(url string, r io.Reader) error {
 	return nil
 }
 
+// AddResourceFromMap adds a schema from an already loaded map to the compiler.
+func (c *Compiler) AddResourceFromMap(url string, doc map[string]any) error {
+	res, err := newResourceFromMap(url, doc)
+	if err != nil {
+		return err
+	}
+	c.resources[res.url] = res
+	return nil
+}
+
 // MustCompile is like Compile but panics if the url cannot be compiled to *Schema.
 // It simplifies safe initialization of global variables holding compiled Schemas.
 func (c *Compiler) MustCompile(url string) *Schema {

--- a/compiler_test.go
+++ b/compiler_test.go
@@ -1,0 +1,23 @@
+package jsonschema
+
+import "testing"
+
+func TestCompiler_AddResourceFromMap(t *testing.T) {
+	c := NewCompiler()
+	err := c.AddResourceFromMap("main.json", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"id": map[string]any{
+				"type":   "string",
+				"format": "uuid",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("main.json")
+	if err := sch.Validate(map[string]any{"id": "00000000-0000-0000-0000-000000000000"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -43,6 +43,22 @@ func newResource(url string, r io.Reader) (*resource, error) {
 	}, nil
 }
 
+func newResourceFromMap(url string, doc map[string]any) (*resource, error) {
+	var err error
+	if strings.IndexByte(url, '#') != -1 {
+		panic(fmt.Sprintf("BUG: newResourceFromMap(%q)", url))
+	}
+	url, err = toAbs(url)
+	if err != nil {
+		return nil, err
+	}
+	return &resource{
+		url:  url,
+		floc: "#",
+		doc:  doc,
+	}, nil
+}
+
 // fillSubschemas fills subschemas in res into r.subresources
 func (r *resource) fillSubschemas(c *Compiler, res *resource) error {
 	if err := c.validateSchema(r, res.doc, res.floc[1:]); err != nil {


### PR DESCRIPTION
This change allows users to add a `resource` to the compiler that was already loaded and unmarshal'ed elsewhere. In my use-case it helps me from needing to re-marshal a schema I already loaded before being able to add it to the `jsonschema` compiler.