### PR TITLE
Expose the schema of a resource while being compiled by an extension compiler

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -68,6 +68,18 @@ func (ctx CompilerContext) CompileRef(ref string, refPath string, applicableOnSa
 	return ctx.c.compileRef(ctx.r, stack, refPath, ctx.res, ref)
 }
 
+// GetResourceSchema provides a pointer to the current resource's schema.
+//
+// Useful in cases where the extension needs to collect metadata about the current
+// target of the compilation, such as the absolute location of the resource's schema.
+func (ctx CompilerContext) GetResourceSchema() *Schema {
+	if ctx.r == nil {
+		return nil
+	}
+
+	return ctx.r.schema
+}
+
 // ValidationContext ---
 
 // ValidationContext provides additional context required in validating for extension.


### PR DESCRIPTION
Sometimes an extension compiler needs to collect metadata about the instance of the keyword being compiled - most notably, its location.
With the proposed method, one can collect the location of the keyword in the compiler method like so:
```go
func (c myCompiler) Compile(ctx jsonschema.CompilerContext, m map[string]interface{}) (jsonschema.ExtSchema, error) {
	if v, ok := m["myKeyword"]; ok {
		location := ctx.GetResourceSchema().Location
		...
	}
	...
}
```