### PR TITLE
Look for deprecated and changed annotations

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -680,6 +680,25 @@ func (c *Compiler) compileMap(r *resource, stack []schemaRef, sref schemaRef, re
 			s.Description = description.(string)
 		}
 		s.Default = m["default"]
+
+		if deprecated, ok := m["deprecated"]; ok {
+			s.Deprecated = deprecated.(bool)
+		}
+		if deprecatedVersion, ok := m["deprecated_version"]; ok {
+			s.DeprecatedVersion = deprecatedVersion.(string)
+		}
+		if deprecatedDescription, ok := m["deprecated_description"]; ok {
+			s.DeprecatedDescription = deprecatedDescription.(string)
+		}
+		if changed, ok := m["changed"]; ok {
+			s.Changed = changed.(bool)
+		}
+		if changedVersion, ok := m["changed_version"]; ok {
+			s.DeprecatedVersion = changedVersion.(string)
+		}
+		if changedDescription, ok := m["changed_description"]; ok {
+			s.DeprecatedDescription = changedDescription.(string)
+		}
 	}
 
 	if r.draft.version >= 6 {

--- a/schema.go
+++ b/schema.go
@@ -99,6 +99,11 @@ type Schema struct {
 	WriteOnly   bool
 	Examples    []interface{}
 	Deprecated  bool
+	Changed     bool
+
+	// deprecation warnings
+	DeprecatedVersion     string
+	DeprecatedDescription string
 
 	// user defined extensions
 	Extensions map[string]ExtSchema
@@ -732,6 +737,14 @@ func (s *Schema) validate(scope []schemaRef, vscope int, spath string, v interfa
 		}
 		// restore dynamic scope
 		scope[len(scope)-1].discard = false
+	}
+
+	if s.Deprecated || s.Changed {
+		deprecated := s.DeprecatedDescription
+		if s.DeprecatedVersion != "" {
+			deprecated += fmt.Sprintf(" (since v%s)", s.DeprecatedVersion)
+		}
+		errors = append(errors, validationError("deprecated", deprecated))
 	}
 
 	for _, ext := range s.Extensions {


### PR DESCRIPTION
These are used by the cloud-init schema for cloud-config

https://raw.githubusercontent.com/canonical/cloud-init/main/cloudinit/config/schemas/schema-cloud-config-v1.json

Example result, when validating with those annotations:

```
  [I#] [S#/allOf/8] allOf failed
    [I#] [S#/allOf/8/$ref] doesn't validate with '/$defs/cc_ca_certs'
      [I#/ca-certs] [S#/$defs/cc_ca_certs/properties/ca-certs/allOf/1] allOf failed
        [I#/ca-certs] [S#/$defs/cc_ca_certs/properties/ca-certs/allOf/1/deprecated] Use ``ca_certs`` instead. (since v22.3)
  [I#] [S#/allOf/49] allOf failed
    [I#] [S#/allOf/49/$ref] doesn't validate with '/$defs/cc_users_groups'
      [I#/users/0] [S#/$defs/cc_users_groups/properties/users/items/oneOf] oneOf failed
        [I#/users/0] [S#/$defs/cc_users_groups/properties/users/items/oneOf/0/type] expected string, but got object
        [I#/users/0] [S#/$defs/cc_users_groups/properties/users/items/oneOf/1/type] expected array, but got object
        [I#/users/0] [S#/$defs/cc_users_groups/properties/users/items/oneOf/2/$ref] doesn't validate with '/$defs/users_groups.user'
          [I#/users/0/uid] [S#/$defs/users_groups.user/properties/uid/oneOf] oneOf failed
            [I#/users/0/uid] [S#/$defs/users_groups.user/properties/uid/oneOf/0/type] expected integer, but got string
            [I#/users/0/uid] [S#/$defs/users_groups.user/properties/uid/oneOf/1/deprecated] The use of ``string`` type is deprecated. Use an ``integer`` instead. (since v22.3)
          [I#/users/0/ssh-authorized-keys] [S#/$defs/users_groups.user/properties/ssh-authorized-keys/allOf/1] allOf failed
            [I#/users/0/ssh-authorized-keys] [S#/$defs/users_groups.user/properties/ssh-authorized-keys/allOf/1/deprecated] Use ``ssh_authorized_keys`` instead. (since v18.3)

```