### PR TITLE
Add external cache

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,18 @@
+retry: &retry_spot_instance
+  automatic:
+    - exit_status: -1
+      limit: 3
+    - exit_status: '*'
+      limit: 3
+
+steps:
+  - label: ":golang: release"
+    key: "release"
+    agents:
+      queue: dedicated
+    retry: *retry_spot_instance
+    command: ".buildkite/steps/release"
+    plugins:
+      - fanduel/gcr#v0.1.2:
+          login: true
+    if: build.tag =~ /v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.buildkite/steps/common
+++ b/.buildkite/steps/common
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+config_git() {
+      echo "configuring git..."
+      git config --global url."git@github.com:".insteadOf "https://github.com/"
+}
+
+
+shout() { echo "$0: $*" >&2; }
+barf() { shout "$*"; exit 111; }
+try() { "$@" || barf "cannot $*"; }
+
+
+
+# vi: ft=sh

--- a/.buildkite/steps/release
+++ b/.buildkite/steps/release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+. .buildkite/steps/common
+
+git fetch --tags
+
+try curl -sL https://git.io/goreleaser | bash
+# vi: ft=sh

--- a/.buildkite/steps/setup
+++ b/.buildkite/steps/setup
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+. .buildkite/steps/common
+
+echo "running: config_git"
+try config_git
+
+echo "running: tidy up"
+try go mod tidy -compat=1.22
+
+echo "running: go vendor"
+try go mod vendor
+
+echo "running: go generate"
+try go generate ./...
+
+#vi: ft=sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,6 @@
+project_name: jsonschema
+builds:
+  - skip: true
+release:
+  github:
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# jsonschema v5.3.1
+# jsonschema Bluecore Fork v5.3.2
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GoDoc](https://godoc.org/github.com/santhosh-tekuri/jsonschema?status.svg)](https://pkg.go.dev/github.com/santhosh-tekuri/jsonschema/v5)
-[![Go Report Card](https://goreportcard.com/badge/github.com/santhosh-tekuri/jsonschema/v5)](https://goreportcard.com/report/github.com/santhosh-tekuri/jsonschema/v5)
-[![Build Status](https://github.com/santhosh-tekuri/jsonschema/actions/workflows/go.yaml/badge.svg?branch=master)](https://github.com/santhosh-tekuri/jsonschema/actions/workflows/go.yaml)
-[![codecov](https://codecov.io/gh/santhosh-tekuri/jsonschema/branch/master/graph/badge.svg?token=JMVj1pFT2l)](https://codecov.io/gh/santhosh-tekuri/jsonschema)
 
 Package jsonschema provides json-schema compilation and validation.
 

--- a/README.md
+++ b/README.md
@@ -214,3 +214,13 @@ https://play.golang.org/p/Hhax3MrtD8r
 
 NOTE: if you are using `gopkg.in/yaml.v3`, then you do not need such conversion. since this library
 returns `map[string]interface{}` if all keys are strings.
+
+# Releasing a new version
+
+Tag the commit you would like to cut a release for with a string that represents the semantic version for the release
+and push that tag to the repository. 
+
+For example, to cut a release at the head of the master branch for v5.3.2 run
+
+```
+git tag v5.3.2 && git push origin v5.3.2

--- a/compiler.go
+++ b/compiler.go
@@ -318,7 +318,6 @@ func (c *Compiler) compileRef(r *resource, stack []schemaRef, refPtr string, res
 		return nil, err
 	}
 	if sr == nil {
-		Ï
 		return nil, fmt.Errorf("jsonschema: %s not found", ref)
 	}
 


### PR DESCRIPTION
This PR adds the ability to have an external cache rather than use the in-memory cache it ships with. We need this because:

- It's not possible to cache all the schema in memory for a single compiler
- Want to use different caching technologies (LRUCache, Redis, etc.)

This will fall back to the in-memory cache if the Get/Set methods are not available (nil). This is important as there are internal compilers used for the base json schema definitions. 