### PR TITLE
Fix minor spelling mistake for the comment on Schema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 )
 
-// Schema is the regpresentation of a compiled
+// Schema is the representation of a compiled
 // jsonschema.
 type Schema struct {
 	up                urlPtr


### PR DESCRIPTION
When looking at the documents I saw a minor spelling mistake `regpresentation -> representation`