### PR TITLE
feat: sort elements prior localization

### DIFF
--- a/kind/kind.go
+++ b/kind/kind.go
@@ -3,6 +3,7 @@ package kind
 import (
 	"fmt"
 	"math/big"
+	"sort"
 	"strings"
 
 	"golang.org/x/text/message"
@@ -622,7 +623,12 @@ func quote(s string) string {
 
 func joinQuoted(arr []string, sep string) string {
 	var sb strings.Builder
-	for _, s := range arr {
+	// After upgrade to Go 1.23 can be replaced just with
+	// ... range slices.Sorted(arr)
+	sarr := make([]string, len(arr))
+	copy(sarr, arr)
+	sort.Strings(sarr)
+	for _, s := range sarr {
 		if sb.Len() > 0 {
 			sb.WriteString(sep)
 		}


### PR DESCRIPTION
Hey,

solves randomized error output in OutputUnit: `additional properties 'kickstart_base64', 'kickstart_text' not allowed` or `additional properties 'kickstart_text', 'kickstart_base64' not allowed`. This is useful for testing schema validations. More details at: https://github.com/santhosh-tekuri/jsonschema/issues/213

Unfortunately, a bit ugly code, I do not want the function to modify the argument therefore making a copy. With Go 1.23 this could be much cleaner.

Cheers.