### PR TITLE
feat: add github output value

### DIFF
--- a/cmd/jv/main.go
+++ b/cmd/jv/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/tidwall/gjson"
+	"io"
 	"net/url"
 	"os"
 	"runtime/debug"
@@ -73,7 +75,7 @@ func main() {
 	}
 
 	// output --
-	if !slices.Contains([]string{"simple", "alt", "flag", "basic", "detailed"}, *output) {
+	if !slices.Contains([]string{"simple", "alt", "flag", "basic", "detailed", "github"}, *output) {
 		eprintln("invalid output: %v", *output)
 		eprintln("")
 		flag.Usage()
@@ -202,6 +204,8 @@ func main() {
 						printJSON(verr.BasicOutput())
 					case "detailed":
 						printJSON(verr.DetailedOutput())
+					case "github":
+						printGitHub(verr.DetailedOutput(), instance)
 					}
 				} else {
 					fmt.Println(err)
@@ -228,4 +232,64 @@ func printJSON(v any) {
 		panic(err)
 	}
 	fmt.Println(string(b))
+}
+
+func printGitHub(o *jsonschema.OutputUnit, file string) {
+	if o.Valid {
+		return
+	}
+
+	if o.Error != nil {
+		bytes, err := o.Error.MarshalJSON()
+		if err != nil {
+			panic(err)
+		}
+		line, err := GetLineNumber(file, toJsonPath(o.InstanceLocation))
+		if err != nil {
+			panic(err)
+		}
+		log := fmt.Sprintf("::error file=%s,line=%d::%s: %s", file, line, o.InstanceLocation, string(bytes))
+		fmt.Println(log)
+	}
+
+	for _, output := range o.Errors {
+		printGitHub(&output, file)
+	}
+}
+
+func toJsonPath(location string) string {
+	location, _ = strings.CutPrefix(location, "/")
+	location = strings.ReplaceAll(location, "/", ".")
+	return location
+}
+
+// GetLineNumber retrieves the line number of a JSON Path match in a JSON file
+func GetLineNumber(jsonFilePath string, jsonPath string) (int, error) {
+	// Open the file
+	file, err := os.Open(jsonFilePath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	b, err := io.ReadAll(file)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	result := gjson.GetBytes(b, jsonPath)
+	if !result.Exists() {
+		return 0, fmt.Errorf("no match found for JSON Path: %s", jsonPath)
+	}
+	
+	lines := strings.Split(string(b), "\n")
+	total := 0
+	for i, line := range lines {
+		total += len(line) + 1 // +1 for the newline character
+		if total >= result.Index {
+			return i + 1, nil // +1 because line numbers are 1-based
+		}
+	}
+
+	return result.Index, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,9 @@ require (
 	github.com/dlclark/regexp2 v1.11.0 // used for testing
 	golang.org/x/text v0.14.0
 )
+
+require (
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,4 +1,6 @@
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=


### PR DESCRIPTION
This feature allow users to output the validations errors as [github error message](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message) using `--output github`.

This is very useful when this library is used as part of a validation tool in GitHub workflows.

---

This is a very naive, non-optimized way of setting the error on the file at the line that errored.

`printGitHub` uses the following behavior:

1. Recursively prints the DetailedOutput
2. If an error exists
    1. Convert the `InstanceLocation` to a JSON Path
    2. Use the `gjson` library to retrieve the index of the JSON Path from the JSON file
    3. Use that index to retrieve the line number (split by line ending and then find in which line the index belongs by summing each line length)

---

There's also no unit test, but it would need some for special cases, might work on that later.