### PR TITLE
avoid plural when AdditionalProperties applies to a single property

### DIFF
--- a/kind/kind.go
+++ b/kind/kind.go
@@ -361,6 +361,9 @@ func (*AdditionalProperties) KeywordPath() []string {
 }
 
 func (k *AdditionalProperties) LocalizedString(p *message.Printer) string {
+	if len(k.Properties) == 1 {
+		return p.Sprintf("additional property %s not allowed", quote(k.Properties[0]))
+	}
 	return p.Sprintf("additional properties %s not allowed", joinQuoted(k.Properties, ", "))
 }
 


### PR DESCRIPTION
makes a friendlier error message when validation error applies to a single property