### PR TITLE
format: ensure ascii in uri, uri-reference

### DIFF
--- a/format.go
+++ b/format.go
@@ -34,7 +34,7 @@ var formats = map[string]*Format{
 	"uri":                   {"uri", validateURI},
 	"iri":                   {"iri", validateIRI},
 	"uri-reference":         {"uri-reference", validateURIReference},
-	"iri-reference":         {"iri-reference", validateURIReference},
+	"iri-reference":         {"iri-reference", validateIRIReference},
 	"uri-template":          {"uri-template", validateURITemplate},
 	"semver":                {"semver", validateSemver},
 }
@@ -534,27 +534,40 @@ func parseURL(s string) (*gourl.URL, error) {
 }
 
 func validateURI(v any) error {
-	return validateRI(v, false)
+	return validateRI(v, false, false)
 }
 
 func validateIRI(v any) error {
-	return validateRI(v, true)
+	return validateRI(v, true, false)
 }
 
-func validateRI(v any, international bool) error {
+func validateURIReference(v any) error {
+	return validateRI(v, false, true)
+}
+
+func validateIRIReference(v any) error {
+	return validateRI(v, true, true)
+}
+
+func validateRI(v any, international bool, reference bool) error {
 	s, ok := v.(string)
 	if !ok {
 		return nil
 	}
 
-	// rfc3986: 2.  Characters
-	//   [..] The ABNF notation defines its terminal values to be non-negative
-	//   integers (codepoints) based on the US-ASCII coded character set
 	if !international {
+		// rfc3986: 2.  Characters
+		//   [..] The ABNF notation defines its terminal values to be
+		//   non-negative integers (codepoints) based on the US-ASCII coded
+		//   character set
 		for _, r := range s {
 			if r > unicode.MaxASCII {
 				return LocalizableError("has unescaped non-ASCII characters")
 			}
+		}
+		// rfc3986 does not list `\` (aka %x5C) as allowed character
+		if strings.Contains(s, `\`) {
+			return LocalizableError(`contains \`)
 		}
 	}
 
@@ -562,22 +575,10 @@ func validateRI(v any, international bool) error {
 	if err != nil {
 		return err
 	}
-	if !u.IsAbs() {
+	if !reference && !u.IsAbs() {
 		return LocalizableError("relative url")
 	}
 	return nil
-}
-
-func validateURIReference(v any) error {
-	s, ok := v.(string)
-	if !ok {
-		return nil
-	}
-	if strings.Contains(s, `\`) {
-		return LocalizableError(`contains \`)
-	}
-	_, err := parseURL(s)
-	return err
 }
 
 func validateURITemplate(v any) error {

--- a/format.go
+++ b/format.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // Format defined specific format.
@@ -536,6 +537,14 @@ func validateURI(v any) error {
 	s, ok := v.(string)
 	if !ok {
 		return nil
+	}
+	// rfc3986: 2.  Characters
+	//   [..] The ABNF notation defines its terminal values to be non-negative
+	//   integers (codepoints) based on the US-ASCII coded character set
+	for _, r := range s {
+		if r > unicode.MaxASCII {
+			return LocalizableError("has unescaped non-ASCII characters")
+		}
 	}
 	u, err := parseURL(s)
 	if err != nil {

--- a/format.go
+++ b/format.go
@@ -565,9 +565,14 @@ func validateRI(v any, international bool, reference bool) error {
 				return LocalizableError("has unescaped non-ASCII characters")
 			}
 		}
-		// rfc3986 does not list `\` (aka %x5C) as allowed character
-		if strings.Contains(s, `\`) {
-			return LocalizableError(`contains \`)
+		// rfc3986 does not list a number of ASCII chars, they are not allowed
+		// its sister RFC lists them explicitely:
+		// rfc3987: 3.1.  Mapping of IRIs to URIs
+		//   [..] Systems accepting IRIs MAY also deal with the printable
+		//   characters in US-ASCII that are not allowed in URIs, namely "<",
+		//   ">", '"', space, "{", "}", "|", "\", "^", and "`" [..]
+		if strings.ContainsAny(s, "<>\" {}|\\^`") {
+			return LocalizableError(`has illegal ASCII characters`)
 		}
 	}
 

--- a/format.go
+++ b/format.go
@@ -32,7 +32,7 @@ var formats = map[string]*Format{
 	"time":                  {"time", validateTime},
 	"date-time":             {"date-time", validateDateTime},
 	"uri":                   {"uri", validateURI},
-	"iri":                   {"iri", validateURI},
+	"iri":                   {"iri", validateIRI},
 	"uri-reference":         {"uri-reference", validateURIReference},
 	"iri-reference":         {"iri-reference", validateURIReference},
 	"uri-template":          {"uri-template", validateURITemplate},
@@ -534,18 +534,30 @@ func parseURL(s string) (*gourl.URL, error) {
 }
 
 func validateURI(v any) error {
+	return validateRI(v, false)
+}
+
+func validateIRI(v any) error {
+	return validateRI(v, true)
+}
+
+func validateRI(v any, international bool) error {
 	s, ok := v.(string)
 	if !ok {
 		return nil
 	}
+
 	// rfc3986: 2.  Characters
 	//   [..] The ABNF notation defines its terminal values to be non-negative
 	//   integers (codepoints) based on the US-ASCII coded character set
-	for _, r := range s {
-		if r > unicode.MaxASCII {
-			return LocalizableError("has unescaped non-ASCII characters")
+	if !international {
+		for _, r := range s {
+			if r > unicode.MaxASCII {
+				return LocalizableError("has unescaped non-ASCII characters")
+			}
 		}
 	}
+
 	u, err := parseURL(s)
 	if err != nil {
 		return err

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri-reference.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri-reference.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "validation of iri strings",
+        "schema": { "format": "iri-reference" },
+        "tests": [
+            {
+                "description": "ok unescaped non US-ASCII characters",
+                "data": "https://example.org/foobar®.txt",
+                "valid": true
+            },
+            {
+                "description": "ok relative unescaped non US-ASCII characters",
+                "data": "/foobar®.txt",
+                "valid": true
+            },
+            {
+                "description": "ok backslash",
+                "data": "/fo\\obar.txt",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri.json
@@ -4,7 +4,7 @@
         "schema": { "format": "iri" },
         "tests": [
             {
-                "description": "ok unescape non US-ASCII characters",
+                "description": "ok unescaped non US-ASCII characters",
                 "data": "https://example.org/foobar®.txt",
                 "valid": true
             }

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/iri.json
@@ -1,0 +1,13 @@
+[
+    {
+        "description": "validation of iri strings",
+        "schema": { "format": "iri" },
+        "tests": [
+            {
+                "description": "ok unescape non US-ASCII characters",
+                "data": "https://example.org/foobar®.txt",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri-reference.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri-reference.json
@@ -1,21 +1,21 @@
 [
     {
-        "description": "validation of uri strings",
-        "schema": { "format": "uri" },
+        "description": "validation of uri-reference strings",
+        "schema": { "format": "uri-reference" },
         "tests": [
             {
-                "description": "ok",
+                "description": "ok absolute",
                 "data": "https://example.org/",
                 "valid": true
             },
             {
-                "description": "invalid userinfo",
-                "data": "https://[@example.org/test.txt",
-                "valid": false
+                "description": "ok relative",
+                "data": "/test.txt",
+                "valid": true
             },
             {
                 "description": "unescaped non US-ASCII characters",
-                "data": "https://example.org/foobar®.txt",
+                "data": "/foobar®.txt",
                 "valid": false
             },
             {

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri.json
@@ -22,6 +22,41 @@
                 "description": "invalid backslash character",
                 "data": "https://example.org/foobar\\.txt",
                 "valid": false
+            },
+            {
+                "description": "invalid \" character",
+                "data": "https://example.org/foobar\".txt",
+                "valid": false
+            },
+            {
+                "description": "invalid <> characters",
+                "data": "https://example.org/foobar<>.txt",
+                "valid": false
+            },
+            {
+                "description": "invalid {} characters",
+                "data": "https://example.org/foobar{}.txt",
+                "valid": false
+            },
+            {
+                "description": "invalid ^ character",
+                "data": "https://example.org/foobar^.txt",
+                "valid": false
+            },
+            {
+                "description": "invalid ` character",
+                "data": "https://example.org/foobar`.txt",
+                "valid": false
+            },
+            {
+                "description": "invalid SPACE character",
+                "data": "https://example.org/foo bar.txt",
+                "valid": false
+            },
+            {
+                "description": "invalid | character",
+                "data": "https://example.org/foobar|.txt",
+                "valid": false
             }
         ]
     }

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/uri.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "validation of uri strings",
+        "schema": { "format": "uri" },
+        "tests": [
+            {
+                "description": "ok",
+                "data": "https://example.org/",
+                "valid": true
+            },
+            {
+                "description": "invalid userinfo",
+                "data": "https://[@example.org/test.txt",
+                "valid": false
+            },
+            {
+                "description": "unescape non US-ASCII characters",
+                "data": "https://example.org/foobar®.txt",
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
  * Add test cases for uri and iri validation.
  * Change validateURI() to additionally check that all chars are ASCII.
  * Add additionally check for disallowed ASCII chars for uri and uri-reference. 
  * Introduce validateIRI() without ASCII range check

resolve #225