### PR TITLE
validation: add type check in equals() for numeric comparison

### DIFF
--- a/util.go
+++ b/util.go
@@ -320,9 +320,15 @@ func equals(v1, v2 any) (bool, ErrorKind) {
 		v2, ok := v2.(string)
 		return ok && v1 == v2, nil
 	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
-		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
-		return ok1 && ok2 && num1.Cmp(num2) == 0, nil
+		switch v2.(type) {
+		case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			// Both v1 and v2 are numeric types
+			num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
+			num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
+			return ok1 && ok2 && num1.Cmp(num2) == 0, nil
+		default:
+			return false, nil
+		}
 	default:
 		return false, &kind.InvalidJsonValue{Value: v1}
 	}

--- a/util.go
+++ b/util.go
@@ -323,7 +323,6 @@ func equals(v1, v2 any) (bool, ErrorKind) {
 		if typeOf(v2) != numberType {
 			return false, nil
 		}
-		// Both v1 and v2 are numeric types
 		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
 		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
 		return ok1 && ok2 && num1.Cmp(num2) == 0, nil

--- a/util.go
+++ b/util.go
@@ -320,15 +320,13 @@ func equals(v1, v2 any) (bool, ErrorKind) {
 		v2, ok := v2.(string)
 		return ok && v1 == v2, nil
 	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		switch v2.(type) {
-		case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			// Both v1 and v2 are numeric types
-			num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
-			num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
-			return ok1 && ok2 && num1.Cmp(num2) == 0, nil
-		default:
+		if typeOf(v2) != numberType {
 			return false, nil
 		}
+		// Both v1 and v2 are numeric types
+		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
+		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
+		return ok1 && ok2 && num1.Cmp(num2) == 0, nil
 	default:
 		return false, &kind.InvalidJsonValue{Value: v1}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package jsonschema
 
 import (
+	"encoding/json"
 	"hash/maphash"
 	"testing"
 )
@@ -72,6 +73,7 @@ func TestEquals(t *testing.T) {
 	}{
 		{1.0, 1, true},
 		{-1.0, -1, true},
+		{json.Number("1"), "1", false},
 	}
 	for _, test := range tests {
 		got, k := equals(test.v1, test.v2)


### PR DESCRIPTION
Previously, equals() compared string "1" and json.Number("1") as equal because both were converted to strings via fmt.Sprint() and parsed as numbers, ignoring type differences.

Now, numeric comparison only occurs when both values are numeric types, preserving JSON type distinction in enum duplicate detection.

Previous errors:
- enum: ["1", 1] fails with "items at 0 and 1 are equal"
- enum: [1, "1"] succeeds

Schema example:
```json
{
  "$schema": "https://json-schema.org/draft-07/schema#",
  "properties": {
    "autoscaling": {
      "description": "autoscaling properties",
      "properties": {
        "minReplicas": {
            "enum": ["1", 1]
        }
      },
      "type": "object"
    }
  },
  "title": "Values",
  "type": "object"
}
```

Closes: #241 