### PR TITLE
validator: check invalid floats NaN/Inf

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -19,6 +19,7 @@ package jsonschema
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 )
 
@@ -126,12 +127,22 @@ const (
 )
 
 func typeOf(v any) jsonType {
-	switch v.(type) {
+	switch v := v.(type) {
 	case nil:
 		return nullType
 	case bool:
 		return booleanType
-	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return invalidType
+		}
+		return numberType
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return invalidType
+		}
+		return numberType
+	case json.Number, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return numberType
 	case string:
 		return stringType

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,32 @@
+package jsonschema_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func TestInvalidFloats(t *testing.T) {
+	c := jsonschema.NewCompiler()
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(`{"minimum": 0}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddResource("schema.json", doc); err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, v := range values {
+		err := sch.Validate(v)
+		if err == nil {
+			t.Errorf("Validate(%v) = nil, want error", v)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #248.

`typeOf()` now returns `invalidType` for NaN/Inf `float64` and `float32` values, so they hit the existing `InvalidJsonValue` error path at validator.go:92-94 instead of reaching `numValidate()` where `big.Rat.SetString` returns nil.

### What changed

- `schema.go`: split the `float64` and `float32` cases out of the numeric type switch in `typeOf()`, adding `math.IsNaN`/`math.IsInf` guards that return `invalidType`
- `nan_inf_test.go`: test that all three values (NaN, +Inf, -Inf) produce a validation error instead of a panic

### Alternative considered

A guard at the top of `numValidate()` would also work, but catching it in `typeOf()` prevents these values from reaching any validation logic at all.