### PR TITLE
format/email: add closing quote check

### DIFF
--- a/format.go
+++ b/format.go
@@ -318,7 +318,7 @@ func validateEmail(v any) error {
 		return LocalizableError("local part more than 64 characters long")
 	}
 
-	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasPrefix(local, `"`) {
+	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasSuffix(local, `"`) {
 		// quoted
 		local := local[1 : len(local)-1]
 		if strings.IndexByte(local, '\\') != -1 || strings.IndexByte(local, '"') != -1 {

--- a/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/email.json
+++ b/testdata/Extra-Test-Suite/tests/draft2020-12/optional/format/email.json
@@ -25,6 +25,11 @@
                 "description": "backslash inside quoted",
                 "data": "\"a\\b\"@gmail.com",
                 "valid": false
+            },
+            {
+                "description": "unclosed quote in local part",
+                "data": "\"unclosed@example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
Fixes #250.

`validateEmail` at format.go:321 uses `strings.HasPrefix` twice instead of `HasPrefix` + `HasSuffix` when checking for quoted local parts. Any email with a leading `"` but no closing quote incorrectly passes format validation.

### What changed

- `format.go`: changed second `HasPrefix` to `HasSuffix` on line 321
- `email_test.go`: added `TestEmailUnclosedQuote` verifying that unclosed quoted local parts are rejected