### PR TITLE
validator/additionalItems: fix instanceLocation

### DIFF
--- a/testdata/Extra-Test-Suite/tests/draft2019-09/additionalItems.json
+++ b/testdata/Extra-Test-Suite/tests/draft2019-09/additionalItems.json
@@ -1,0 +1,25 @@
+[
+    {
+        "description": "check index in error",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2019-09/schema",
+            "items": [
+                { "type": "string" },
+                { "type": "string" }
+            ],
+            "additionalItems": {
+                "type": "boolean"
+            }
+        },
+        "tests": [
+            {
+                "description": "with fraction",
+                "data": [ "a", "b", "c" ],
+                "valid": false,
+                "errors": [
+                    "at '/2' [S#/additionalItems/type]: got string, want boolean"
+                ]
+            }
+        ]
+    }
+]

--- a/validator.go
+++ b/validator.go
@@ -375,7 +375,7 @@ func (vd *validator) arrValidate(arr []any) {
 				}
 			case *Schema:
 				for i, item := range arr[evaluated:] {
-					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(i)))
+					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(evaluated+i)))
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #252.

The `additionalItems` validation loop iterates over `arr[evaluated:]` which re-indexes from 0, but uses the loop index `i` directly in `strconv.Itoa(i)` for the instance location. This reports `/0` instead of `/2` (or whatever the correct offset is) in validation errors.

### What changed

- `validator.go`: changed `strconv.Itoa(i)` to `strconv.Itoa(evaluated+i)` on line 378
- `additionalitems_test.go`: added `TestAdditionalItemsErrorLocation` using draft-04 schema to verify the error points to the correct array index