### PR TITLE
fix: support typed Go slices and maps in validation

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
 )
 
 // Schema is the representation of a compiled
@@ -151,6 +152,15 @@ func typeOf(v any) jsonType {
 	case map[string]any:
 		return objectType
 	default:
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Slice, reflect.Array:
+			return arrayType
+		case reflect.Map:
+			if rv.Type().Key().Kind() == reflect.String {
+				return objectType
+			}
+		}
 		return invalidType
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 	"slices"
 	"strconv"
 	"unicode/utf8"
@@ -166,6 +167,24 @@ func (vd *validator) validate() (*uneval, error) {
 		vd.strValidate(v)
 	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		vd.numValidate(v)
+	default:
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Slice, reflect.Array:
+			arr := make([]any, rv.Len())
+			for i := range arr {
+				arr[i] = rv.Index(i).Interface()
+			}
+			vd.arrValidate(arr)
+		case reflect.Map:
+			if rv.Type().Key().Kind() == reflect.String {
+				obj := make(map[string]any, rv.Len())
+				for _, key := range rv.MapKeys() {
+					obj[key.String()] = rv.MapIndex(key).Interface()
+				}
+				vd.objValidate(obj)
+			}
+		}
 	}
 
 	if len(vd.errors) == 0 || !vd.boolResult {
@@ -930,6 +949,27 @@ func unevalFrom(v any, sch *Schema, callerNeeds bool) *uneval {
 			uneval.items = map[int]struct{}{}
 			for i := sch.numItemsEvaluated; i < len(v); i++ {
 				uneval.items[i] = struct{}{}
+			}
+		}
+	default:
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Map:
+			if rv.Type().Key().Kind() == reflect.String {
+				if !sch.allPropsEvaluated && (callerNeeds || sch.UnevaluatedProperties != nil) {
+					uneval.props = map[string]struct{}{}
+					for _, key := range rv.MapKeys() {
+						uneval.props[key.String()] = struct{}{}
+					}
+				}
+			}
+		case reflect.Slice, reflect.Array:
+			l := rv.Len()
+			if !sch.allItemsEvaluated && (callerNeeds || sch.UnevaluatedItems != nil) && sch.numItemsEvaluated < l {
+				uneval.items = map[int]struct{}{}
+				for i := sch.numItemsEvaluated; i < l; i++ {
+					uneval.items[i] = struct{}{}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #238

## Problem

The validator only accepts `[]any` for JSON arrays and `map[string]any` for JSON objects. Typed Go slices like `[]string` or `[]map[string]interface{}` are rejected with:

```
invalid jsonType []string
```

Even though these types serialize correctly to JSON and match the schema.

## Fix

Use `reflect` as a fallback in `typeOf()` to detect:
- Slices/arrays → treated as JSON arrays
- Maps with string keys → treated as JSON objects

When validation needs to iterate over these values (in `arrValidate`/`objValidate` and `unevalFrom`), the typed collections are converted to `[]any` / `map[string]any` first.

## Testing

All existing tests pass. Manually verified:

```go
schema.Validate([]string{"hello", "world"})          // ✅ was: invalid jsonType
schema.Validate([]map[string]string{{"key": "val"}}) // ✅ was: invalid jsonType
```