### PR TITLE
validator/propertyNames: fix instanceLocation and keywordLocation

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -285,18 +285,15 @@ func (vd *validator) objValidate(obj map[string]any) {
 	// propertyNames --
 	if s.PropertyNames != nil {
 		for pname := range obj {
-			sch, meta, resources := s.PropertyNames, vd.meta, vd.resources
-			res := vd.metaResource(sch)
-			if res != nil {
-				meta = res.dialect.getSchema(vd.assertVocabs, vd.vocabularies)
-				sch = meta
-			}
-			if err := sch.validate(pname, vd.regexpEngine, meta, resources, vd.assertVocabs, vd.vocabularies); err != nil {
+			if err := vd.validatePropertyName(s.PropertyNames, pname); err != nil {
 				verr := err.(*ValidationError)
-				verr.InstanceLocation = vd.vloc
-				verr.SchemaURL = s.PropertyNames.Location
-				verr.ErrorKind = &kind.PropertyNames{Property: pname}
-				vd.addErr(verr)
+				var causes []*ValidationError
+				if _, ok := verr.ErrorKind.(*kind.Group); ok {
+					causes = verr.Causes
+				} else {
+					causes = []*ValidationError{verr}
+				}
+				vd.addErrors(causes, &kind.PropertyNames{Property: pname})
 			}
 		}
 	}
@@ -691,6 +688,27 @@ func (vd *validator) validateVal(sch *Schema, v any, vtok string) error {
 		sch:          sch,
 		scp:          scp,
 		uneval:       uneval,
+		errors:       nil,
+		boolResult:   vd.boolResult,
+		regexpEngine: vd.regexpEngine,
+		meta:         vd.meta,
+		resources:    vd.resources,
+		assertVocabs: vd.assertVocabs,
+		vocabularies: vd.vocabularies,
+	}
+	subvd.handleMeta()
+	_, err := subvd.validate()
+	return err
+}
+
+func (vd *validator) validatePropertyName(sch *Schema, pname string) error {
+	scp := vd.scp.child(sch, "", vd.scp.vid+1)
+	subvd := validator{
+		v:            pname,
+		vloc:         vd.vloc,
+		sch:          sch,
+		scp:          scp,
+		uneval:       unevalFrom(pname, sch, false),
 		errors:       nil,
 		boolResult:   vd.boolResult,
 		regexpEngine: vd.regexpEngine,

--- a/validator_test.go
+++ b/validator_test.go
@@ -30,3 +30,57 @@ func TestInvalidFloats(t *testing.T) {
 		}
 	}
 }
+
+func TestPropertyNamesLocation(t *testing.T) {
+	c := jsonschema.NewCompiler()
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(`{
+		"type": "object",
+		"properties": {
+			"foo": {
+				"type": "object",
+				"propertyNames": {"pattern": "^[a-z]+$"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddResource("schema.json", doc); err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = sch.Validate(map[string]any{
+		"foo": map[string]any{"BAR": "baz"},
+	})
+	if err == nil {
+		t.Fatal("Validate() = nil, want error")
+	}
+
+	out := err.(*jsonschema.ValidationError).BasicOutput()
+
+	want := map[string]string{
+		"/properties/foo/propertyNames":         "/foo",
+		"/properties/foo/propertyNames/pattern": "/foo",
+	}
+	got := map[string]string{}
+	for _, u := range out.Errors {
+		got[u.KeywordLocation] = u.InstanceLocation
+	}
+	for kwLoc, instLoc := range want {
+		actual, ok := got[kwLoc]
+		if !ok {
+			t.Errorf("missing unit with keywordLocation %q; got units %v", kwLoc, got)
+			continue
+		}
+		if actual != instLoc {
+			t.Errorf("keywordLocation %q: instanceLocation = %q, want %q", kwLoc, actual, instLoc)
+		}
+	}
+	if _, doubled := got["/properties/foo/propertyNames/propertyNames"]; doubled {
+		t.Errorf("keywordLocation has duplicated /propertyNames; got units %v", got)
+	}
+}


### PR DESCRIPTION
Fixes #258.

`propertyNames` validation called the top-level `(*Schema).validate` entry to check each property name. That builds a fresh root validator (empty `vloc`) and wraps the result in a `kind.Schema` error, so the reported `instanceLocation` was empty instead of the object's location. The caller then overwrote `SchemaURL` with `PropertyNames.Location`, and since `kind.PropertyNames.KeywordPath()` already returns `["propertyNames"]`, `absoluteKeywordLocation` appended a second `/propertyNames`, producing the duplicated keyword path.

### What changed

- `validator.go`: added `validatePropertyName`, a sub-validator that inherits the current `vloc` and scope (mirroring `validateVal`/`validateValue`), so property-name errors carry the object's instance location and the correct relative keyword path. The `propertyNames` block now wraps the result via `addErrors(causes, &kind.PropertyNames{...})`, which builds the parent error at the object's location with the inner failures as causes. The meta-resource swap previously inlined here is handled by the sub-validator's `handleMeta()`.
- `validator_test.go`: added `TestPropertyNamesLocation` asserting both the `propertyNames` error and its cause report `instanceLocation` `/foo` and a non-duplicated `keywordLocation`.

For the issue's example, the output is now:

```
- at '/foo' [S#/properties/foo/propertyNames]: invalid propertyName 'BAR'
  - at '/foo' [S#/properties/foo/propertyNames/pattern]: 'BAR' does not match pattern '^[a-z]+$'
```