### PR TITLE
fix: ignore dependencies in modern drafts

### DIFF
--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -1,0 +1,86 @@
+package jsonschema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+type rejectingLoader struct{}
+
+func (rejectingLoader) Load(rawURL string) (any, error) {
+	return nil, fmt.Errorf("unexpected load of %s", rawURL)
+}
+
+func compileSchema(t *testing.T, source string) *jsonschema.Schema {
+	t.Helper()
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", doc); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func jsonValue(t *testing.T, source string) any {
+	t.Helper()
+	value, err := jsonschema.UnmarshalJSON(strings.NewReader(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func TestDependenciesKeywordFollowsDeclaredDraft(t *testing.T) {
+	t.Run("2020-12 does not compile annotation contents", func(t *testing.T) {
+		doc, err := jsonschema.UnmarshalJSON(strings.NewReader(`{
+			"$schema":"https://json-schema.org/draft/2020-12/schema",
+			"dependencies":{"note":{"$schema":"https://invalid.example/schema"}}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		compiler := jsonschema.NewCompiler()
+		compiler.UseLoader(rejectingLoader{})
+		if err := compiler.AddResource("schema.json", doc); err != nil {
+			t.Fatal(err)
+		}
+		schema, err := compiler.Compile("schema.json")
+		if err != nil {
+			t.Fatalf("inactive dependencies content was compiled: %v", err)
+		}
+		if err := schema.Validate(jsonValue(t, `{"note":1}`)); err != nil {
+			t.Fatalf("inactive dependencies keyword was enforced: %v", err)
+		}
+	})
+
+	t.Run("2020-12 reference can target annotation content", func(t *testing.T) {
+		schema := compileSchema(t, `{
+			"$schema":"https://json-schema.org/draft/2020-12/schema",
+			"dependencies":{"value":{"type":"string"}},
+			"$ref":"#/dependencies/value"
+		}`)
+		if err := schema.Validate(jsonValue(t, `1`)); err == nil {
+			t.Fatal("referenced annotation schema was not enforced")
+		}
+	})
+
+	t.Run("draft-07 retains assertion behavior", func(t *testing.T) {
+		schema := compileSchema(t, `{
+			"$schema":"http://json-schema.org/draft-07/schema#",
+			"dependencies":{"x":["y"]}
+		}`)
+		if err := schema.Validate(jsonValue(t, `{"x":1}`)); err == nil {
+			t.Fatal("draft-07 dependency was not enforced")
+		}
+	})
+}

--- a/draft.go
+++ b/draft.go
@@ -81,7 +81,7 @@ var (
 		version: 2019,
 		url:     "https://json-schema.org/draft/2019-09/schema",
 		id:      "$id",
-		subschemas: joinSubschemas(Draft7.subschemas,
+		subschemas: joinSubschemas(withoutSubschemaKeyword(Draft7.subschemas, "dependencies"),
 			schemaPath("$defs/*"),
 			schemaPath("dependentSchemas/*"),
 			schemaPath("unevaluatedProperties"),
@@ -357,4 +357,17 @@ func joinSubschemas(a1 []SchemaPath, a2 ...SchemaPath) []SchemaPath {
 	a = append(a, a1...)
 	a = append(a, a2...)
 	return a
+}
+
+func withoutSubschemaKeyword(paths []SchemaPath, keyword Prop) []SchemaPath {
+	filtered := make([]SchemaPath, 0, len(paths))
+	for _, path := range paths {
+		if len(path) > 0 {
+			if property, ok := path[0].(Prop); ok && property == keyword {
+				continue
+			}
+		}
+		filtered = append(filtered, path)
+	}
+	return filtered
 }

--- a/objcompiler.go
+++ b/objcompiler.go
@@ -126,14 +126,16 @@ func (c *objCompiler) compileDraft4(s *Schema) error {
 		}
 		s.AdditionalProperties = c.enqueueAdditional("additionalProperties")
 
-		if m := c.objVal("dependencies"); m != nil {
-			s.Dependencies = map[string]any{}
-			for pname, pvalue := range m {
-				if arr, ok := pvalue.([]any); ok {
-					s.Dependencies[pname] = toStrings(arr)
-				} else {
-					ptr := c.up.ptr.append2("dependencies", pname)
-					s.Dependencies[pname] = c.enqueuePtr(ptr)
+		if s.DraftVersion < 2019 {
+			if m := c.objVal("dependencies"); m != nil {
+				s.Dependencies = map[string]any{}
+				for pname, pvalue := range m {
+					if arr, ok := pvalue.([]any); ok {
+						s.Dependencies[pname] = toStrings(arr)
+					} else {
+						ptr := c.up.ptr.append2("dependencies", pname)
+						s.Dependencies[pname] = c.enqueuePtr(ptr)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- stop treating the removed `dependencies` keyword as an assertion in draft 2019-09 and 2020-12
- exclude its contents from eager modern-draft subschema discovery
- preserve on-demand compilation when an explicit JSON Pointer reference targets annotation content
- retain draft-07 dependency behavior

## Verification

- `go test ./...`
- AutoReview clean, confidence 0.98
