### PR TITLE
format: reject signed numeric tokens in ipv4 and time

### DIFF
--- a/format.go
+++ b/format.go
@@ -209,6 +209,22 @@ func validateDuration(v any) error {
 	return nil
 }
 
+// isAllDigits reports whether s is non-empty and consists solely of ASCII
+// digits. strconv.Atoi accepts a leading '+' or '-' sign, but the RFC 3339
+// time and dotted-quad IPv4 grammars are digit-only, so numeric tokens are
+// checked with this before parsing.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func validateIPV4(v any) error {
 	s, ok := v.(string)
 	if !ok {
@@ -221,6 +237,9 @@ func validateIPV4(v any) error {
 	for _, group := range groups {
 		if len(group) > 1 && group[0] == '0' {
 			return LocalizableError("leading zeros")
+		}
+		if !isAllDigits(group) {
+			return LocalizableError("decimal must contain only digits")
 		}
 		n, err := strconv.Atoi(group)
 		if err != nil {
@@ -403,6 +422,9 @@ func validateTime(v any) error {
 	// parse hh:mm:ss
 	var hms []int
 	for _, tok := range strings.SplitN(str[:8], ":", 3) {
+		if !isAllDigits(tok) {
+			return LocalizableError("invalid hour/min/sec")
+		}
 		i, err := strconv.Atoi(tok)
 		if err != nil {
 			return LocalizableError("invalid hour/min/sec")
@@ -458,6 +480,9 @@ func validateTime(v any) error {
 
 		var zhm []int
 		for _, tok := range strings.SplitN(str, ":", 2) {
+			if !isAllDigits(tok) {
+				return LocalizableError("invalid hour/min in offset")
+			}
 			i, err := strconv.Atoi(tok)
 			if err != nil {
 				return LocalizableError("invalid hour/min in offset")

--- a/format_sign_test.go
+++ b/format_sign_test.go
@@ -1,0 +1,55 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// TestFormatRejectsSignedNumericTokens checks that the numeric tokens of the
+// ipv4, time, date-time and email (bracketed IPv4 literal) formats are parsed
+// as digit-only. strconv.Atoi accepts a leading '+'/'-' sign, so signed tokens
+// such as "+4" or "-0" used to validate even though the RFC 3339 and dotted-quad
+// grammars are digit-only.
+func TestFormatRejectsSignedNumericTokens(t *testing.T) {
+	compile := func(t *testing.T, format string) *jsonschema.Schema {
+		t.Helper()
+		c := jsonschema.NewCompiler()
+		c.AssertFormat()
+		url := "mem://format-sign.json"
+		if err := c.AddResource(url, map[string]any{"type": "string", "format": format}); err != nil {
+			t.Fatalf("add resource: %v", err)
+		}
+		sch, err := c.Compile(url)
+		if err != nil {
+			t.Fatalf("compile %s: %v", format, err)
+		}
+		return sch
+	}
+
+	cases := []struct {
+		format string
+		value  string
+		valid  bool
+	}{
+		{"ipv4", "1.2.3.4", true},
+		{"ipv4", "1.2.3.+4", false},
+		{"ipv4", "+1.2.3.4", false},
+		{"ipv4", "1.2.3.-0", false},
+		{"time", "12:30:00Z", true},
+		{"time", "+9:30:00Z", false},
+		{"time", "12:+9:00Z", false},
+		{"time", "12:00:00+09:+0", false},
+		{"date-time", "2020-01-01T12:30:00Z", true},
+		{"date-time", "2020-01-01T+9:30:00Z", false},
+		{"email", "a@b.com", true},
+		{"email", "a@[1.2.3.+4]", false},
+	}
+	for _, tc := range cases {
+		sch := compile(t, tc.format)
+		got := sch.Validate(tc.value) == nil
+		if got != tc.valid {
+			t.Errorf("format %q value %q: valid=%v, want %v", tc.format, tc.value, got, tc.valid)
+		}
+	}
+}


### PR DESCRIPTION
The `ipv4` and `time` format validators parse their numeric tokens with `strconv.Atoi`, which accepts a leading `+`/`-` sign, so signed tokens validate even though the dotted-quad and RFC 3339 grammars are digit-only:

```
ipv4       "1.2.3.+4"              -> valid (want invalid)
ipv4       "+1.2.3.4"              -> valid
ipv4       "1.2.3.-0"              -> valid
time       "+9:30:00Z"            -> valid
time       "12:+9:00Z"            -> valid
time       "12:00:00+09:+0"       -> valid
date-time  "2020-01-01T+9:30:00Z" -> valid  (date-time reuses the time check)
email      "a@[1.2.3.+4]"         -> valid  (bracketed IPv4 literal reuses ipv4)
```

`validateDuration` and `validateSemver` in the same file already reject non-digit characters with an explicit loop. This adds a small `isAllDigits` helper and applies it before the three `strconv.Atoi` call sites (ipv4 octet, time hh:mm:ss, offset hh:mm), so `date-time` and `email` inherit the fix.

Added `TestFormatRejectsSignedNumericTokens`. Checked: `go test ./...` (including the official JSON-Schema-Test-Suite), `go vet ./...`, `gofmt -l`.
