### PR TITLE
perf: use type switch for integer validation

### DIFF
--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/maphash"
+	"math"
 	"math/big"
 	gourl "net/url"
 	"path/filepath"
@@ -270,8 +271,21 @@ func strVal(obj map[string]any, prop string) (string, bool) {
 }
 
 func isInteger(num any) bool {
-	rat, ok := new(big.Rat).SetString(fmt.Sprint(num))
-	return ok && rat.IsInt()
+	switch n := num.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32:
+		f := float64(n)
+		return !math.IsInf(f, 0) && !math.IsNaN(f) && f == math.Trunc(f)
+	case float64:
+		return !math.IsInf(n, 0) && !math.IsNaN(n) && n == math.Trunc(n)
+	case json.Number:
+		rat, ok := new(big.Rat).SetString(string(n))
+		return ok && rat.IsInt()
+	default:
+		rat, ok := new(big.Rat).SetString(fmt.Sprint(num))
+		return ok && rat.IsInt()
+	}
 }
 
 // quote returns single-quoted string.


### PR DESCRIPTION
Many times the argument passed to `isInteger(num any) bool` is already an integer type, which means that we don't need any further validation logic or memory allocations. Other times, we can reduce the validation efforts significantly. We still keep the existing implementation as fallback

### Benchmark
```
goos: darwin
goarch: arm64
pkg: github.com/santhosh-tekuri/jsonschema/v6
cpu: Apple M2 Max
                                        │    old.txt     │               new.txt               │
                                        │     sec/op     │   sec/op     vs base                │
IsInteger/case=signed-12                   2028.00n ± 1%   25.78n ± 0%  -98.73% (p=0.000 n=10)
IsInteger/case=unsigned-12                 1070.50n ± 2%   14.59n ± 0%  -98.64% (p=0.000 n=10)
IsInteger/case=float64_integral-12         2084.00n ± 0%   13.47n ± 0%  -99.35% (p=0.000 n=10)
IsInteger/case=float64_fractional-12      1812.000n ± 2%   9.735n ± 2%  -99.46% (p=0.000 n=10)
IsInteger/case=float64_nonfinite-12        199.550n ± 0%   5.662n ± 1%  -97.16% (p=0.000 n=10)
IsInteger/case=float32-12                  1523.00n ± 0%   15.51n ± 0%  -98.98% (p=0.000 n=10)
IsInteger/case=jsonnumber_integral-12       1289.0n ± 0%   945.2n ± 1%  -26.67% (p=0.000 n=10)
IsInteger/case=jsonnumber_fractional-12      877.9n ± 1%   645.1n ± 2%  -26.51% (p=0.000 n=10)
IsInteger/case=jsonnumber_invalid-12        240.50n ± 0%   95.77n ± 0%  -60.18% (p=0.000 n=10)
IsInteger/case=mixed-12                     11.736µ ± 0%   1.822µ ± 0%  -84.48% (p=0.000 n=10)
geomean                                      1.230µ        58.39n       -95.25%

                                        │   old.txt    │                  new.txt                  │
                                        │     B/op     │     B/op      vs base                     │
IsInteger/case=signed-12                    888.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=unsigned-12                  512.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_integral-12        1.642Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_fractional-12      1.446Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_nonfinite-12         108.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float32-12                   992.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=jsonnumber_integral-12       760.0 ± 0%     696.0 ± 0%    -8.42% (p=0.000 n=10)
IsInteger/case=jsonnumber_fractional-12     512.0 ± 0%     480.0 ± 0%    -6.25% (p=0.000 n=10)
IsInteger/case=jsonnumber_invalid-12        96.00 ± 0%     72.00 ± 0%   -25.00% (p=0.000 n=10)
IsInteger/case=mixed-12                   6.863Ki ± 0%   1.219Ki ± 0%   -82.24% (p=0.000 n=10)
geomean                                     708.4                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                        │   old.txt   │                 new.txt                 │
                                        │  allocs/op  │ allocs/op   vs base                     │
IsInteger/case=signed-12                   72.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=unsigned-12                 38.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_integral-12         59.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_fractional-12       47.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float64_nonfinite-12        6.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=float32-12                  55.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)
IsInteger/case=jsonnumber_integral-12      44.00 ± 0%   39.00 ± 0%   -11.36% (p=0.000 n=10)
IsInteger/case=jsonnumber_fractional-12    32.00 ± 0%   28.00 ± 0%   -12.50% (p=0.000 n=10)
IsInteger/case=jsonnumber_invalid-12       5.000 ± 0%   3.000 ± 0%   -40.00% (p=0.000 n=10)
IsInteger/case=mixed-12                   358.00 ± 0%   70.00 ± 0%   -80.45% (p=0.000 n=10)
geomean                                    38.02                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```