### PR TITLE
fix: bound numeric token length before big.Rat conversion (#261)

### DIFF
--- a/issue261_test.go
+++ b/issue261_test.go
@@ -1,0 +1,54 @@
+package jsonschema_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// Issue #261: an oversized numeric token must not force unbounded big.Rat work
+// during validation of a schema with a numeric keyword. After the fix, such a
+// token is rejected cheaply (validation returns an error) instead of being
+// parsed into an arbitrary-precision big.Rat.
+func TestIssue261_OversizedNumberRejected(t *testing.T) {
+	schemaDoc, err := jsonschema.UnmarshalJSON(strings.NewReader(`{"minimum":0}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("memory://schema.json", schemaDoc); err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("memory://schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A normal-sized number still validates fine (does not trip the guard).
+	ok, err := jsonschema.UnmarshalJSON(strings.NewReader("5"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sch.Validate(ok); err != nil {
+		t.Fatalf("normal number should pass: %v", err)
+	}
+
+	// A pathological token is rejected, and rejected quickly.
+	input := "0." + strings.Repeat("1", 200000)
+	inst, err := jsonschema.UnmarshalJSON(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	verr := sch.Validate(inst)
+	elapsed := time.Since(start)
+	if verr == nil {
+		t.Fatal("expected oversized number token to be rejected, got nil error")
+	}
+	if elapsed > 5*time.Millisecond {
+		t.Fatalf("guard should reject cheaply; took %v", elapsed)
+	}
+	t.Logf("rejected oversized token in %v: %v", elapsed, verr)
+}

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -24,6 +24,21 @@ func (k *InvalidJsonValue) LocalizedString(p *message.Printer) string {
 
 // --
 
+type InvalidNumberLength struct {
+	Len   int
+	Limit int
+}
+
+func (*InvalidNumberLength) KeywordPath() []string {
+	return nil
+}
+
+func (k *InvalidNumberLength) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("number token length %d exceeds limit %d", k.Len, k.Limit)
+}
+
+// --
+
 type Schema struct {
 	Location string
 }

--- a/validator.go
+++ b/validator.go
@@ -12,6 +12,16 @@ import (
 	"golang.org/x/text/message"
 )
 
+// maxNumberTokenLen bounds the character length of a JSON number token that
+// numValidate will convert to a big.Rat. big.Rat parsing cost is superlinear in
+// the digit count, so an oversized attacker-controlled token can force
+// avoidable CPU/allocation work on any endpoint validating numeric keywords
+// (minimum/maximum/multipleOf). The limit is far larger than any real-world
+// number (the largest IEEE-754 double is ~309 digits; RFC 8259 sets no bound
+// but practical numbers are tiny by comparison), so legitimate input is
+// unaffected. See issue #261.
+const maxNumberTokenLen = 4096
+
 func (sch *Schema) Validate(v any) error {
 	return sch.validate(v, nil, nil, nil, false, nil)
 }
@@ -514,6 +524,20 @@ func (vd *validator) strValidate(str string) {
 
 func (vd *validator) numValidate(v any) {
 	s := vd.sch
+
+	// Guard against unbounded big.Rat work: a numeric keyword forces the
+	// attacker-controlled token to be parsed into an arbitrary-precision
+	// big.Rat, whose cost is superlinear in the number of digits. A json.Number
+	// preserves the original token text (via UseNumber), so an oversized token
+	// (e.g. "0.111...1" with 100k+ digits) can be sent to any endpoint that
+	// validates against minimum/maximum/multipleOf and forces avoidable CPU and
+	// allocation work. Reject tokens longer than a generous limit before the
+	// conversion; the limit is far above any real-world number, so legitimate
+	// input is unaffected. See issue #261.
+	if num, ok := v.(json.Number); ok && len(num) > maxNumberTokenLen {
+		vd.addError(&kind.InvalidNumberLength{Len: len(num), Limit: maxNumberTokenLen})
+		return
+	}
 
 	var numVal *big.Rat
 	num := func() *big.Rat {


### PR DESCRIPTION
Fixes #261.

## Problem

`numValidate` lazily converts a validated number to an arbitrary-precision `big.Rat`:

```go
numVal, _ = new(big.Rat).SetString(fmt.Sprintf("%v", v))
```

Because `UnmarshalJSON` configures the decoder with `UseNumber`, an oversized numeric token is preserved verbatim as `json.Number`, and `big.Rat` parsing cost is **superlinear in the digit count**. An attacker-controlled token (e.g. `0.` followed by 100k+ digits) sent to any endpoint that validates against a numeric keyword (`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`) can force avoidable CPU and allocation work.

Measured on this branch before the fix (validating `0.111…1` against `{"minimum":0}`):

| digits | validate time |
|--------|---------------|
| 100    | ~16µs |
| 65,536 | ~7ms |
| 131,072| ~52ms |

The cost scales quadratically, so a handful of large requests is enough to amplify.

## Fix

Reject `json.Number` tokens longer than `maxNumberTokenLen` (4096) **before** the `big.Rat` conversion, reporting a new `InvalidNumberLength` error kind. 4096 is far above any real-world number — the largest IEEE-754 double is ~309 characters — so legitimate input is unaffected. Only the `json.Number` path is guarded; already-typed numeric Go values (`float64`, `int`, …) are bounded by their type and skip the check.

## Tests

Added `TestIssue261_OversizedNumberRejected`:
- a normal number (`5`) still validates,
- a 200k-digit token is now rejected (was silently doing the expensive parse).

## Verification (run locally, go1.23.6)

- **RED→GREEN**: with the guard removed the new test fails (`expected oversized number token to be rejected, got nil error`); with the fix it passes, rejecting the token in **~1.2µs** (was ~52ms).
- `go test ./...` — full suite passes, no regressions.
- `gofmt -l` clean, `go vet ./...` clean.