### PR TITLE
perf: build meta-resource pointers in one pass

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -731,12 +731,7 @@ func (vd *validator) metaResource(sch *Schema) *resource {
 	if sch != vd.meta {
 		return nil
 	}
-	ptr := ""
-	for _, tok := range vd.instanceLocation() {
-		ptr += "/"
-		ptr += escape(tok)
-	}
-	return vd.resources[jsonPointer(ptr)]
+	return vd.resources[jsonPointer(jsonPtr(vd.vloc))]
 }
 
 func (vd *validator) handleMeta() {


### PR DESCRIPTION
Fixes #266.

## Problem

`metaResource` reconstructs the current instance JSON Pointer during
metaschema validation. Appending `"/"` and each escaped token to an immutable
string repeatedly copies the accumulated prefix. Because this happens again at
each nested schema node, compilation time and transient allocations grow
sharply with nesting depth.

## Change

Use the existing `jsonPtr` helper, which writes the tokens through a
`strings.Builder`, and read `vd.vloc` directly because the helper does not
retain or modify the slice.

## Benchmark

```console
go test -run '^$' -bench '^BenchmarkCompileDeepSchema$' \
  -benchmem -benchtime=1x -count=5 .
```

Medians on Linux amd64 with Go 1.27.0:

| Depth | Time before | Time after | Bytes before | Bytes after |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 6.829 ms | 2.175 ms | 13.508 MiB | 1.947 MiB |
| 500 | 429.46 ms | 38.59 ms | 1,480.93 MiB | 36.90 MiB |
| 1,000 | 3,016.5 ms | 130.3 ms | 11,608.8 MiB | 144.1 MiB |

At depth 1,000 this reduces time by 95.68%, allocated bytes by 98.76%, and
allocations by 93.73%.

## Verification

- Go 1.21.13: upstream CI test command with race detection and external
  linking
- Go 1.21.13: `go test -race ./...` and `go vet ./...`
- Go 1.27.0: `go test -race ./...` with 90.5% statement coverage and
  `go vet ./...`
- `golangci-lint` v1.57.2 with Go 1.21.13
