### PR TITLE
perf: prune impossible tagged oneOf branches

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -208,6 +208,7 @@ func (c *Compiler) doCompile(up urlPtr) (*Schema, error) {
 		compiled++
 	}
 	for _, sch := range *q {
+		sch.prepareOneOfDiscriminator()
 		c.schemas[sch.up] = sch
 	}
 	return c.schemas[up], nil

--- a/oneof.go
+++ b/oneof.go
@@ -1,0 +1,135 @@
+package jsonschema
+
+import "sort"
+
+// oneOfDiscriminator describes a required string property whose const value can
+// rule out some oneOf branches. A branch without a statically recognizable
+// constraint is deliberately left unclassified and must always be evaluated.
+type oneOfDiscriminator struct {
+	property   string
+	values     []string
+	classified []bool
+}
+
+func (s *Schema) prepareOneOfDiscriminator() {
+	if len(s.OneOf) < 2 {
+		return
+	}
+
+	type candidate struct {
+		values     []string
+		classified []bool
+		count      int
+		distinct   map[string]struct{}
+	}
+	candidates := map[string]*candidate{}
+	for i, branch := range s.OneOf {
+		for property, value := range branch.requiredStringConsts() {
+			c := candidates[property]
+			if c == nil {
+				c = &candidate{
+					values:     make([]string, len(s.OneOf)),
+					classified: make([]bool, len(s.OneOf)),
+					distinct:   map[string]struct{}{},
+				}
+				candidates[property] = c
+			}
+			c.values[i] = value
+			c.classified[i] = true
+			c.count++
+			c.distinct[value] = struct{}{}
+		}
+	}
+
+	// Pick deterministically when multiple required const properties could be
+	// used. Classifying more branches gives validation the best opportunity to
+	// avoid work. At least two distinct values are necessary to be useful for a
+	// valid instance.
+	properties := make([]string, 0, len(candidates))
+	for property := range candidates {
+		properties = append(properties, property)
+	}
+	sort.Strings(properties)
+	var best *candidate
+	var bestProperty string
+	for _, property := range properties {
+		c := candidates[property]
+		if len(c.distinct) < 2 {
+			continue
+		}
+		if best == nil || c.count > best.count {
+			best = c
+			bestProperty = property
+		}
+	}
+	if best != nil {
+		s.oneOfDiscriminator = &oneOfDiscriminator{
+			property:   bestProperty,
+			values:     best.values,
+			classified: best.classified,
+		}
+	}
+}
+
+// requiredStringConsts returns only constraints that are sufficient to prove
+// that every object accepted by s has the named property and that its value is
+// the returned string. It intentionally recognizes a small, conservative shape:
+// required + properties + const, through local compiled $ref chains.
+func (s *Schema) requiredStringConsts() map[string]string {
+	constraints := map[string]string{}
+	seen := map[*Schema]struct{}{}
+	for s != nil {
+		if _, ok := seen[s]; ok {
+			break
+		}
+		seen[s] = struct{}{}
+
+		for _, property := range s.Required {
+			propertySchema := s.Properties[property]
+			if propertySchema == nil {
+				continue
+			}
+			if value, ok := propertySchema.localStringConst(); ok {
+				constraints[property] = value
+			}
+		}
+
+		if s.Ref == nil || s.resource != s.Ref.resource {
+			break
+		}
+		s = s.Ref
+	}
+	return constraints
+}
+
+func (s *Schema) localStringConst() (string, bool) {
+	seen := map[*Schema]struct{}{}
+	for s != nil {
+		if _, ok := seen[s]; ok {
+			return "", false
+		}
+		seen[s] = struct{}{}
+		if s.Const != nil {
+			value, ok := (*s.Const).(string)
+			return value, ok
+		}
+		if s.Ref == nil || s.resource != s.Ref.resource {
+			return "", false
+		}
+		s = s.Ref
+	}
+	return "", false
+}
+
+func (d *oneOfDiscriminator) value(instance any) (string, bool) {
+	object, ok := instance.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	value, ok := object[d.property].(string)
+	return value, ok
+}
+
+func (d *oneOfDiscriminator) excludes(branch int, value string) bool {
+	return d.classified[branch] && d.values[branch] != value
+}

--- a/oneof_test.go
+++ b/oneof_test.go
@@ -1,0 +1,262 @@
+package jsonschema
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestOneOfDiscriminatorThroughLocalRefs(t *testing.T) {
+	sch := compileOneOfTestSchema(t, `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$defs": {
+			"catKind": {"const": "cat"},
+			"dogKind": {"const": "dog"},
+			"cat": {
+				"type": "object",
+				"required": ["kind"],
+				"properties": {"kind": {"$ref": "#/$defs/catKind"}}
+			},
+			"dog": {
+				"type": "object",
+				"required": ["kind"],
+				"properties": {"kind": {"$ref": "#/$defs/dogKind"}}
+			}
+		},
+		"oneOf": [
+			{"$ref": "#/$defs/cat"},
+			{"$ref": "#/$defs/dog"},
+			{"required": ["name"]}
+		]
+	}`)
+
+	d := sch.oneOfDiscriminator
+	if d == nil {
+		t.Fatal("oneOf discriminator was not detected")
+	}
+	if got, want := d.property, "kind"; got != want {
+		t.Fatalf("discriminator property = %q, want %q", got, want)
+	}
+	if got, want := d.values, []string{"cat", "dog", ""}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("discriminator values = %v, want %v", got, want)
+	}
+	if got, want := d.classified, []bool{true, true, false}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("classified branches = %v, want %v", got, want)
+	}
+}
+
+func TestOneOfDiscriminatorPreservesValidation(t *testing.T) {
+	const schema = `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"oneOf": [
+			{
+				"required": ["kind", "a"],
+				"properties": {
+					"kind": {"const": "cat"},
+					"a": {"type": "integer"}
+				}
+			},
+			{
+				"required": ["kind", "b"],
+				"properties": {
+					"kind": {"const": "cat"},
+					"b": {"type": "string"}
+				}
+			},
+			{
+				"required": ["kind", "bark"],
+				"properties": {
+					"kind": {"const": "dog"},
+					"bark": {"type": "boolean"}
+				}
+			},
+			{
+				"required": ["name"],
+				"properties": {"name": {"type": "string"}}
+			}
+		],
+		"unevaluatedProperties": false
+	}`
+
+	tests := []struct {
+		name     string
+		instance any
+	}{
+		{
+			name:     "selected branch matches",
+			instance: map[string]any{"kind": "dog", "bark": true},
+		},
+		{
+			name:     "selected branch fails with full diagnostics",
+			instance: map[string]any{"kind": "dog", "bark": "yes"},
+		},
+		{
+			name:     "branches sharing discriminator remain candidates",
+			instance: map[string]any{"kind": "cat", "a": 1, "b": "two"},
+		},
+		{
+			name:     "unclassified branch remains a candidate",
+			instance: map[string]any{"kind": "dog", "bark": true, "name": "Fido"},
+		},
+		{
+			name:     "unknown discriminator can match unclassified branch",
+			instance: map[string]any{"kind": "bird", "name": "Polly"},
+		},
+		{
+			name:     "missing discriminator uses full validation",
+			instance: map[string]any{"name": "Mystery"},
+		},
+		{
+			name:     "non-string discriminator uses full validation",
+			instance: map[string]any{"kind": 7, "name": "Seven"},
+		},
+		{
+			name:     "matching branch contributes evaluated properties",
+			instance: map[string]any{"kind": "cat", "a": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertOneOfOptimizedMatchesBaseline(t, schema, tt.instance)
+		})
+	}
+}
+
+func TestOneOfDiscriminatorRequiresRequiredConst(t *testing.T) {
+	sch := compileOneOfTestSchema(t, `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"oneOf": [
+			{"properties": {"kind": {"const": "cat"}}},
+			{"properties": {"kind": {"const": "dog"}}}
+		]
+	}`)
+	if sch.oneOfDiscriminator != nil {
+		t.Fatal("optional const property must not be used as a discriminator")
+	}
+}
+
+func BenchmarkOneOfConstDiscriminator(b *testing.B) {
+	optimized := compileOneOfBenchmarkSchema(b)
+	baseline := compileOneOfBenchmarkSchema(b)
+	baseline.oneOfDiscriminator = nil
+
+	payload := make(map[string]any, 24)
+	for i := 0; i < 24; i++ {
+		payload[fmt.Sprintf("field%d", i)] = "value"
+	}
+	instance := map[string]any{
+		"kind":    "kind6",
+		"payload": payload,
+	}
+	if err := optimized.Validate(instance); err != nil {
+		b.Fatal(err)
+	}
+
+	for _, benchmark := range []struct {
+		name string
+		sch  *Schema
+	}{
+		{name: "baseline", sch: baseline},
+		{name: "optimized", sch: optimized},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := benchmark.sch.Validate(instance); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func assertOneOfOptimizedMatchesBaseline(t *testing.T, source string, instance any) {
+	t.Helper()
+	sch := compileOneOfTestSchema(t, source)
+	if sch.oneOfDiscriminator == nil {
+		t.Fatal("test schema has no compiled oneOf discriminator")
+	}
+	got := sch.Validate(instance)
+	sch.oneOfDiscriminator = nil
+	want := sch.Validate(instance)
+	gotDiagnostic := canonicalValidationError(got)
+	wantDiagnostic := canonicalValidationError(want)
+	if gotDiagnostic != wantDiagnostic {
+		t.Fatalf("optimized validation differs from baseline\noptimized: %#v\nbaseline:  %#v", got, want)
+	}
+}
+
+func canonicalValidationError(err error) string {
+	if err == nil {
+		return ""
+	}
+	verr := err.(*ValidationError)
+	causes := make([]string, len(verr.Causes))
+	for i, cause := range verr.Causes {
+		causes[i] = canonicalValidationError(cause)
+	}
+	// Object properties are validated in map iteration order, so cause order is
+	// not part of the diagnostic contract even without this optimization.
+	sort.Strings(causes)
+	return fmt.Sprintf("%s|%v|%T:%#v|%v", verr.SchemaURL, verr.InstanceLocation, verr.ErrorKind, verr.ErrorKind, causes)
+}
+
+func compileOneOfTestSchema(t testing.TB, source string) *Schema {
+	t.Helper()
+	doc, err := UnmarshalJSON(strings.NewReader(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := NewCompiler()
+	if err := c.AddResource("schema.json", doc); err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sch
+}
+
+func compileOneOfBenchmarkSchema(b *testing.B) *Schema {
+	b.Helper()
+	var source strings.Builder
+	source.WriteString(`{
+		"$schema":"https://json-schema.org/draft/2020-12/schema",
+		"$defs":{
+			"payload":{
+				"type":"object",
+				"required":[`)
+	for i := 0; i < 24; i++ {
+		if i > 0 {
+			source.WriteByte(',')
+		}
+		fmt.Fprintf(&source, `"field%d"`, i)
+	}
+	source.WriteString(`],"properties":{`)
+	for i := 0; i < 24; i++ {
+		if i > 0 {
+			source.WriteByte(',')
+		}
+		fmt.Fprintf(&source, `"field%d":{"type":"string"}`, i)
+	}
+	source.WriteString(`}}},"oneOf":[`)
+	for i := 0; i < 12; i++ {
+		if i > 0 {
+			source.WriteByte(',')
+		}
+		fmt.Fprintf(&source, `{
+			"type":"object",
+			"required":["kind","payload"],
+			"properties":{
+				"kind":{"const":"kind%d"},
+				"payload":{"$ref":"#/$defs/payload"}
+			}
+		}`, i)
+	}
+	source.WriteString(`]}`)
+	return compileOneOfTestSchema(b, source.String())
+}

--- a/schema.go
+++ b/schema.go
@@ -33,6 +33,8 @@ type Schema struct {
 	allItemsEvaluated bool
 	numItemsEvaluated int
 
+	oneOfDiscriminator *oneOfDiscriminator
+
 	DraftVersion int
 	Location     string
 

--- a/validator.go
+++ b/validator.go
@@ -599,25 +599,7 @@ func (vd *validator) condValidate() {
 
 	// oneOf
 	if len(s.OneOf) > 0 {
-		var matched = -1
-		var errors []*ValidationError
-		for i, sch := range s.OneOf {
-			if err := vd.validateSelf(sch, "", matched != -1); err != nil {
-				if matched == -1 {
-					errors = append(errors, err.(*ValidationError))
-				}
-			} else {
-				if matched == -1 {
-					matched = i
-				} else {
-					vd.addError(&kind.OneOf{Subschemas: []int{matched, i}})
-					break
-				}
-			}
-		}
-		if matched == -1 {
-			vd.addErrors(errors, &kind.OneOf{Subschemas: nil})
-		}
+		vd.oneOfValidate()
 	}
 
 	// if, then, else --
@@ -630,6 +612,51 @@ func (vd *validator) condValidate() {
 			vd.addErr(vd.validateSelf(s.Else, "", false))
 		}
 	}
+}
+
+func (vd *validator) oneOfValidate() {
+	s := vd.sch
+	if discriminator := s.oneOfDiscriminator; discriminator != nil {
+		if value, ok := discriminator.value(vd.v); ok {
+			matched, _, duplicate := vd.validateOneOfBranches(discriminator, value)
+			if duplicate || matched != -1 {
+				return
+			}
+			// No candidate matched. Validate every branch again so an invalid
+			// instance retains the complete diagnostics produced without this
+			// optimization. Failed candidate validation cannot alter unevaluated
+			// property/item tracking in the parent validator.
+		}
+	}
+
+	matched, errors, _ := vd.validateOneOfBranches(nil, "")
+	if matched == -1 {
+		vd.addErrors(errors, &kind.OneOf{Subschemas: nil})
+	}
+}
+
+// validateOneOfBranches skips branches excluded by discriminator, or evaluates
+// every branch when discriminator is nil. It returns the first match, errors
+// preceding that match, and whether a second match made the oneOf invalid.
+func (vd *validator) validateOneOfBranches(discriminator *oneOfDiscriminator, value string) (int, []*ValidationError, bool) {
+	matched := -1
+	var errors []*ValidationError
+	for i, sch := range vd.sch.OneOf {
+		if discriminator != nil && discriminator.excludes(i, value) {
+			continue
+		}
+		if err := vd.validateSelf(sch, "", matched != -1); err != nil {
+			if matched == -1 {
+				errors = append(errors, err.(*ValidationError))
+			}
+		} else if matched == -1 {
+			matched = i
+		} else {
+			vd.addError(&kind.OneOf{Subschemas: []int{matched, i}})
+			return matched, errors, true
+		}
+	}
+	return matched, errors, false
 }
 
 func (vd *validator) unevalValidate() {


### PR DESCRIPTION
## Summary

Optimize validation of tagged `oneOf` unions without changing their semantics.

At compile time, the validator now detects a conservative discriminator when
branches require the same object property to equal different string constants.
Constraints are recognized directly and through static, same-resource `$ref`
chains.

During validation it:

- skips only branches whose required constant provably differs from the instance;
- still evaluates branches sharing the selected value;
- still evaluates every unclassified branch;
- uses the original exhaustive path for missing or non-string discriminators;
- reruns the exhaustive path when no candidate matches, preserving the existing
  complete diagnostics.

The schema remains ordinary JSON Schema and `oneOf` still means exactly one
matching branch.

## Motivation

Tagged unions commonly use a required property with a `const`, but validation
currently traverses every branch even when most are impossible from that
property alone. In recursive schemas this creates substantial CPU and allocation
overhead.

The included synthetic benchmark improves approximately:

| | Baseline | Optimized |
|---|---:|---:|
| Time | 189 µs | 25 µs |
| Allocated | 49.5 KB | 6.36 KB |
| Allocations | 896 | 113 |

That is approximately 7.6× faster.

A real consumer benchmark using a recursive 31.5 KB document schema improved:

- schema validation: 75.28 ms → 4.77 ms;
- allocations: 20.2 MB / 378k → 1.09 MB / 16.2k.

## Correctness

Coverage includes:

- constraints reached through local `$ref` chains;
- branches sharing the same discriminator value;
- unclassified branches;
- missing, unknown, and non-string discriminator values;
- `unevaluatedProperties` bookkeeping;
- preservation of complete failure diagnostics.

Verification performed:

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- configured linters

PS: I ran into this bottleneck with a heavily used schema of ours, where validation was 90%+ of time on a slow request. I had Codex 5.6 Ultra investigate, and it suggested adding this fast-path to the library, as no application level change would give us much improvement. I hope this contribution is either acceptable to you or at least proves that this would be a big performance gain and we can integrate it in some shape or form.