### PR TITLE
fix: prevent InstanceLocation from being overwritten by sibling validation

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -293,7 +293,7 @@ func (vd *validator) objValidate(obj map[string]any) {
 			}
 			if err := sch.validate(pname, vd.regexpEngine, meta, resources, vd.assertVocabs, vd.vocabularies); err != nil {
 				verr := err.(*ValidationError)
-				verr.InstanceLocation = vd.vloc
+				verr.InstanceLocation = vd.instanceLocation()
 				verr.SchemaURL = s.PropertyNames.Location
 				verr.ErrorKind = &kind.PropertyNames{Property: pname}
 				vd.addErr(verr)
@@ -504,7 +504,7 @@ func (vd *validator) strValidate(str string) {
 		}
 		if err = sch.validate(*deserialized, vd.regexpEngine, meta, resources, vd.assertVocabs, vd.vocabularies); err != nil {
 			verr := err.(*ValidationError)
-			verr.InstanceLocation = vd.vloc
+			verr.InstanceLocation = vd.instanceLocation()
 			verr.SchemaURL = s.Location
 			verr.ErrorKind = &kind.ContentSchema{}
 			vd.addErr(verr)

--- a/validator_test.go
+++ b/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 )
 
 func TestInvalidFloats(t *testing.T) {
@@ -29,4 +30,55 @@ func TestInvalidFloats(t *testing.T) {
 			t.Errorf("Validate(%v) = nil, want error", v)
 		}
 	}
+}
+
+// Regression: propertyNames/contentSchema retained vd.vloc directly, so a
+// sibling's append could overwrite a retained error's InstanceLocation. The
+// root/a/b/arr depth gives the array vloc spare capacity, so arr[1] clobbers
+// arr[0]'s location unless it is cloned.
+func TestPropertyNamesInstanceLocationNotMutated(t *testing.T) {
+	schema := `{"properties":{"a":{"properties":{"b":{"properties":{
+		"arr":{"items":{"propertyNames":{"pattern":"^[a-z]+$"}}}}}}}}}`
+	instance := `{"a":{"b":{"arr":[{"BADKEY":1},{}]}}}`
+
+	c := jsonschema.NewCompiler()
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schema))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AddResource("schema.json", doc); err != nil {
+		t.Fatal(err)
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst, err := jsonschema.UnmarshalJSON(strings.NewReader(instance))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verr, ok := sch.Validate(inst).(*jsonschema.ValidationError)
+	if !ok {
+		t.Fatal("want a *jsonschema.ValidationError")
+	}
+	pn := findErrorByKind[*kind.PropertyNames](verr)
+	if pn == nil {
+		t.Fatal("no propertyNames error in tree")
+	}
+	if got := strings.Join(pn.InstanceLocation, "/"); got != "a/b/arr/0" {
+		t.Errorf("InstanceLocation = %q, want %q", got, "a/b/arr/0")
+	}
+}
+
+func findErrorByKind[T jsonschema.ErrorKind](v *jsonschema.ValidationError) *jsonschema.ValidationError {
+	if _, ok := v.ErrorKind.(T); ok {
+		return v
+	}
+	for _, c := range v.Causes {
+		if r := findErrorByKind[T](c); r != nil {
+			return r
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

`propertyNames` and `contentSchema` store the instance location on a
validation error without cloning it, so a later sibling can overwrite it.
This makes those errors sometimes report the wrong `InstanceLocation`.

## The bug

Both sites do:

```go
verr.InstanceLocation = vd.vloc
```

But `vd.vloc`'s backing array is reused as the validator descends
(`vd.vloc = append(vd.vloc, tok)`). If there's spare capacity, a sibling's
append writes over the slots a retained error is still pointing at — so its
`InstanceLocation` changes out from under it.

Every other error path already clones via `vd.instanceLocation()`. These
two were the exception.

## The fix

Use `vd.instanceLocation()` (which does `slices.Clone`) at both sites:

```go
verr.InstanceLocation = vd.instanceLocation()
```

This is on the error path only, so there's no impact on validation
performance.

## Test

Added a regression test that nests objects so an array's location slice has
spare capacity, then fails `propertyNames` on the first of two array items.
Before the fix the error reports `a/b/arr/1` instead of `a/b/arr/0`; after
the fix it's correct.

All existing unit tests and the JSON Schema Test Suite still pass.